### PR TITLE
Add core dependencies

### DIFF
--- a/services/mcp-material/requirements-core.txt
+++ b/services/mcp-material/requirements-core.txt
@@ -1,1 +1,8 @@
 # Core dependencies
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pydantic>=2.7
+pydantic-settings>=2.3
+orjson>=3.9
+loguru>=0.7
+python-multipart>=0.0.9


### PR DESCRIPTION
## Summary
- define core requirements for mcp-material service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a749094814832291952f38da6f2889