### PR TITLE
Add extra dependencies for MCP material service

### DIFF
--- a/services/mcp-material/requirements-extras.txt
+++ b/services/mcp-material/requirements-extras.txt
@@ -1,1 +1,12 @@
-# Optional dependencies
+# добавим позже на шаге 2
+pdfplumber>=0.11
+camelot-py[cv]>=0.11
+pytesseract>=0.3
+opencv-python-headless>=4.10
+sentence-transformers>=3.0
+faiss-cpu>=1.7
+rapidfuzz>=3.9
+ifcopenshell>=0.7
+ezdxf>=1.3
+pandas>=2.2
+openpyxl>=3.1


### PR DESCRIPTION
## Summary
- add dependencies for PDF parsing, OCR, vector search, and CAD support to MCP material service's extras requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a749c9bcb483229a270f2f14a74856