### PR TITLE
Add base configuration for mcp-material service

### DIFF
--- a/services/mcp-material/app/core/config.py
+++ b/services/mcp-material/app/core/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings
+from pydantic import Field
+from pathlib import Path
+
+
+class Settings(BaseSettings):
+    APP_NAME: str = "mcp-material"
+    ENV: str = "dev"
+    HOST: str = "0.0.0.0"
+    PORT: int = 8080
+
+    DATA_ROOT: Path = Field(default=Path("./data"))
+    RESOURCES_ROOT: Path = Field(default=Path("./resources"))
+
+    class Config:
+        env_file = ".env"
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add pydantic-based settings for mcp-material

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74b7374c883229fe5b3961fa04907