### PR TITLE
Add common schemas for mcp-material service

### DIFF
--- a/services/mcp-material/app/schemas/common.py
+++ b/services/mcp-material/app/schemas/common.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class Health(BaseModel):
+    status: str = "ok"
+    service: str = "mcp-material"
+    version: str = "0.0.1"
+
+
+class Error(BaseModel):
+    detail: str


### PR DESCRIPTION
## Summary
- add Health and Error schemas for service responses

## Testing
- `black app/schemas/common.py`
- `ruff check app/schemas/common.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74fe9e6d48322aa16069bb5578a47