### PR TITLE
Add BOM schemas

### DIFF
--- a/services/mcp-material/app/schemas/bom.py
+++ b/services/mcp-material/app/schemas/bom.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+
+
+class BOMItem(BaseModel):
+    code: Optional[str] = None
+    name: str
+    unit: str
+    qty: float
+    props: Optional[Dict[str, Any]] = None
+    source: Optional[str] = None
+
+
+class BOM(BaseModel):
+    items: List[BOMItem] = Field(default_factory=list)
+
+
+class PricedItem(BOMItem):
+    unit_price: float
+    currency: str = "EUR"
+    price_source: Optional[str] = None
+    lead_time_days: Optional[int] = None
+
+
+class PricedBOM(BaseModel):
+    items: List[PricedItem]
+    subtotal: float
+    currency: str = "EUR"
+    gaps: Optional[list] = None


### PR DESCRIPTION
## Summary
- define BOMItem and BOM pydantic models
- add PricedItem and PricedBOM models for costed materials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a753535e2483228d4a4961da72d019