### PR TITLE
Add EU-Central material pricebook and catalog entries

### DIFF
--- a/services/mcp-material/resources/catalog/materials.jsonl
+++ b/services/mcp-material/resources/catalog/materials.jsonl
@@ -1,0 +1,2 @@
+{"code":"MAT-001","canonical_name":"Бетон C25/30","class":"concrete","props":{"strength":"C25/30","density":2400},"synonyms":["бетон м300","concrete c25/30"]}
+{"code":"MAT-002","canonical_name":"Кирпич М150","class":"brick","props":{"grade":"M150"},"synonyms":["brick m150","кирпич рядовой"]}

--- a/services/mcp-material/resources/pricebook/EU-Central/pricebook.jsonl
+++ b/services/mcp-material/resources/pricebook/EU-Central/pricebook.jsonl
@@ -1,0 +1,2 @@
+{"code":"MAT-001","name":"Бетон C25/30","unit":"m3","unit_price":95.4,"currency":"EUR","lead_time_days":14,"updated":"2025-08-01"}
+{"code":"MAT-002","name":"Кирпич М150","unit":"m2","unit_price":12.1,"currency":"EUR","lead_time_days":7,"updated":"2025-08-01"}


### PR DESCRIPTION
## Summary
- add EU-Central pricebook entries for concrete and brick materials
- define corresponding catalog entries with properties and synonyms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a756abfbb88322a29c84c26329ee11