### PR TITLE
Add Dockerfile for mcp-material service

### DIFF
--- a/services/mcp-material/Dockerfile
+++ b/services/mcp-material/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements-core.txt /app/
+RUN pip install --no-cache-dir -r requirements-core.txt
+
+COPY app /app/app
+COPY resources /app/resources
+ENV PYTHONPATH=/app
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host=0.0.0.0", "--port=8080", "--proxy-headers"]


### PR DESCRIPTION
## Summary
- add Dockerfile for mcp-material service that installs dependencies and runs FastAPI app with uvicorn

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a759bcb2d483228caf4580077d1538