### PR TITLE
Add docker-compose for mcp-material service

### DIFF
--- a/services/mcp-material/docker-compose.yml
+++ b/services/mcp-material/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  mcp-material:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - ENV=dev
+      - HOST=0.0.0.0
+      - PORT=8080
+      - DATA_ROOT=/app/data
+      - RESOURCES_ROOT=/app/resources
+    volumes:
+      - ./resources:/app/resources:ro
+      - ./data:/app/data
+


### PR DESCRIPTION
## Summary
- add docker-compose file for mcp-material service

## Testing
- `PYTHONPATH=services/mcp-material pytest services/mcp-material/tests/test_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75a6a9f10832292c6f1ff4cd6301a