### PR TITLE
Add Makefile for mcp-material service

### DIFF
--- a/services/mcp-material/Makefile
+++ b/services/mcp-material/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run dev test lint format docker-up docker-build
+
+run:
+	uvicorn app.main:app --host 0.0.0.0 --port 8080
+
+dev:
+	ENV=dev uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
+
+test:
+	pytest -q
+
+docker-build:
+	docker build -t mcp-material:dev .
+
+docker-up:
+	docker compose up --build


### PR DESCRIPTION
## Summary
- add Makefile for running, development, testing, and Docker helpers in mcp-material service

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75be56e4c83228ec63f6cfaa73601