### PR TITLE
Add reportlab test dependency and install instructions

### DIFF
--- a/services/mcp-material/README.md
+++ b/services/mcp-material/README.md
@@ -1,3 +1,9 @@
 # MCP Material Service
 
 Initial scaffold for the MCP Material service.
+
+## Step 1 notes
+For PDF parsing in tests we use reportlab (test dependency). To run tests:
+pip install -r requirements-core.txt
+pip install -r requirements-extras.txt
+pytest -q

--- a/services/mcp-material/requirements-extras.txt
+++ b/services/mcp-material/requirements-extras.txt
@@ -10,3 +10,4 @@ ifcopenshell>=0.7
 ezdxf>=1.3
 pandas>=2.2
 openpyxl>=3.1
+reportlab>=4.2


### PR DESCRIPTION
## Summary
- add reportlab package to test extras
- document extra requirements installation steps for running tests

## Testing
- `pip install -r requirements-core.txt`
- `pip install -r requirements-extras.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a768c6e5688322b3f98f4f83795486