### PR TITLE
Improve PDF table parsing and tidy imports

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, APIRouter, HTTPException
+from fastapi import FastAPI, APIRouter, HTTPException, Response
 from fastapi.responses import ORJSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
@@ -34,7 +34,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-@ app.middleware("http")
+
+@app.middleware("http")
 async def access_log(request, call_next):
     logger.info(f"{request.method} {request.url}")
     try:
@@ -45,15 +46,22 @@ async def access_log(request, call_next):
         logger.exception("Unhandled error")
         raise
 
+
 @app.get("/health", response_model=Health, tags=["health"], summary="Health check")
 def health():
     return Health(status="ok", service="mcp-material", version="0.0.1")
+
 
 router = APIRouter(prefix="/mcp/material", tags=["mcp"])
 
 resolver = ResourceUriResolver()
 
-@router.post("/parse_drawing", response_model=ParseDrawingResponse, summary="Parse PDF/DWG/IFC into raw specs")
+
+@router.post(
+    "/parse_drawing",
+    response_model=ParseDrawingResponse,
+    summary="Parse PDF/DWG/IFC into raw specs",
+)
 def parse_drawing(body: ParseDrawingRequest):
     path: Path = resolver.resolve(body.file_uri)
     if not path.exists():
@@ -66,22 +74,37 @@ def parse_drawing(body: ParseDrawingRequest):
     # DWG (not implemented yet)
     raise HTTPException(status_code=415, detail=f"Unsupported file type: {suffix}")
 
-@router.post("/extract_bom", response_model=BOM, responses={501: {"model": Error}}, summary="Build normalized BOM from specs/scope")
+
+@router.post(
+    "/extract_bom",
+    response_model=BOM,
+    responses={501: {"model": Error}},
+    summary="Build normalized BOM from specs/scope",
+)
 def extract_bom(body: ExtractBOMRequest):
     raise HTTPException(status_code=501, detail="Not implemented in step 0")
 
-@router.post("/price_bom", response_model=PricedBOM, responses={501: {"model": Error}}, summary="Apply regional pricebook to BOM")
+
+@router.post(
+    "/price_bom",
+    response_model=PricedBOM,
+    responses={501: {"model": Error}},
+    summary="Apply regional pricebook to BOM",
+)
 def price_bom(body: PriceBOMRequest):
     raise HTTPException(status_code=501, detail="Not implemented in step 0")
 
-@router.post("/suggest_substitutions", responses={501: {"model": Error}}, summary="Suggest alternates for gaps with constraints")
+
+@router.post(
+    "/suggest_substitutions",
+    responses={501: {"model": Error}},
+    summary="Suggest alternates for gaps with constraints",
+)
 def suggest_substitutions(body: SuggestSubsRequest):
     raise HTTPException(status_code=501, detail="Not implemented in step 0")
 
-app.include_router(router)
 
-from fastapi import Response
-from app.core.resource_uri import ResourceUriResolver
+app.include_router(router)
 
 resolver_dbg = ResourceUriResolver()
 

--- a/services/mcp-material/app/parsers/pdf_parser.py
+++ b/services/mcp-material/app/parsers/pdf_parser.py
@@ -18,7 +18,12 @@ def _plumber_tables(pdf_path: Path) -> List[Dict[str, Any]]:
     with pdfplumber.open(pdf_path) as pdf:
         for pi, page in enumerate(pdf.pages):
             try:
-                tables = page.extract_tables()
+                tables = page.extract_tables(
+                    {
+                        "vertical_strategy": "text",
+                        "horizontal_strategy": "text",
+                    }
+                )
             except Exception:
                 tables = []
             for ti, t in enumerate(tables or []):

--- a/services/mcp-material/app/parsers/utils.py
+++ b/services/mcp-material/app/parsers/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Tuple, Optional
+from typing import Optional
 
 HEADER_ALIASES = {
     "наименование": ["наименование", "название", "material", "item", "наим."],
@@ -7,6 +7,7 @@ HEADER_ALIASES = {
     "количество": ["кол-во", "количество", "кол.", "qty", "объем", "объём"],
     "марка": ["марка", "тип", "артикул", "brand", "code"],
 }
+
 
 def canonical_header(h: str) -> str:
     s = re.sub(r"\s+", " ", h.strip().lower())
@@ -22,10 +23,23 @@ def canonical_header(h: str) -> str:
         return "марка"
     return "наименование" if len(s) <= 3 else s
 
+
 _UNIT_MAP = {
-    "м2": "m2", "м³": "m3", "м3": "m3", "м": "m", "шт": "pcs", "кг": "kg", "т": "t",
-    "m2": "m2", "m3": "m3", "m": "m", "pcs": "pcs", "kg": "kg", "t": "t",
+    "м2": "m2",
+    "м³": "m3",
+    "м3": "m3",
+    "м": "m",
+    "шт": "pcs",
+    "кг": "kg",
+    "т": "t",
+    "m2": "m2",
+    "m3": "m3",
+    "m": "m",
+    "pcs": "pcs",
+    "kg": "kg",
+    "t": "t",
 }
+
 
 def normalize_unit(u: Optional[str]) -> Optional[str]:
     if not u:
@@ -35,7 +49,9 @@ def normalize_unit(u: Optional[str]) -> Optional[str]:
     s = re.sub(r"\s+", "", s)
     return _UNIT_MAP.get(s, s)
 
+
 _NUM_RE = re.compile(r"^[\s]*([+-]?[0-9]+(?:[.,][0-9]+)?)")
+
 
 def parse_number(val) -> Optional[float]:
     if val is None:

--- a/services/mcp-material/tests/test_parse_pdf.py
+++ b/services/mcp-material/tests/test_parse_pdf.py
@@ -1,4 +1,3 @@
-import io
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 from fastapi.testclient import TestClient
@@ -8,9 +7,9 @@ from app.core.config import settings
 
 client = TestClient(app)
 
+
 def _make_pdf_table(tmp_path: Path) -> Path:
     p = tmp_path / "spec.pdf"
-    buf = io.BytesIO()
     c = canvas.Canvas(str(p), pagesize=A4)
     # simple text table imitation
     y = 800
@@ -29,6 +28,7 @@ def _make_pdf_table(tmp_path: Path) -> Path:
     c.save()
     return p
 
+
 def test_parse_pdf(tmp_path, monkeypatch):
     # prepare resource:// path
     proj = settings.DATA_ROOT / "projects" / "t1" / "files"
@@ -37,7 +37,9 @@ def test_parse_pdf(tmp_path, monkeypatch):
     target = proj / "spec.pdf"
     target.write_bytes(pdf_path.read_bytes())
 
-    r = client.post("/mcp/material/parse_drawing", json={"file_uri": "resource://project/t1/files/spec.pdf"})
+    r = client.post(
+        "/mcp/material/parse_drawing", json={"file_uri": "resource://project/t1/files/spec.pdf"}
+    )
     assert r.status_code == 200, r.text
     js = r.json()
     assert "specs" in js and isinstance(js["specs"], list)


### PR DESCRIPTION
## Summary
- enhance pdf table detection using text-based strategy
- clean up unused imports and restructure FastAPI debug imports
- streamline test PDF generation

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76d76e290832288041725d5136511