### PR TITLE
docs: add detailed project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # Bob
 
 Это продукт для оптимизации работы архитектора.
+
+## Структура репозитория
+
+- `services/mcp-material` — сервис извлечения спецификаций материалов и расчёта их стоимости.
+
+## Быстрый старт
+
+Перейдите в каталог сервиса и установите зависимости:
+
+```bash
+cd services/mcp-material
+pip install -r requirements-core.txt
+pip install -r requirements-extras.txt
+```
+
+Запуск приложения в режиме разработки:
+
+```bash
+make dev
+```
+
+Запуск через Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+## Тестирование
+
+```bash
+cd services/mcp-material
+pytest -q
+```

--- a/services/mcp-material/README.md
+++ b/services/mcp-material/README.md
@@ -1,9 +1,47 @@
 # MCP Material Service
 
-Initial scaffold for the MCP Material service.
+Сервис для извлечения спецификаций материалов из чертежей и расчёта стоимости.
 
-## Step 1 notes
-For PDF parsing in tests we use reportlab (test dependency). To run tests:
+## Возможности
+
+- `GET /health` — проверка состояния сервиса.
+- `POST /mcp/material/parse_drawing` — конвертация PDF или IFC в список позиций.
+- `POST /mcp/material/extract_bom` — формирование нормализованной спецификации (заглушка).
+- `POST /mcp/material/price_bom` — оценка стоимости спецификации (заглушка).
+- `POST /mcp/material/suggest_substitutions` — подбор альтернатив (заглушка).
+
+## URI ресурсов
+
+Сервис использует схему `resource://` для доступа к данным. Поддерживаются варианты:
+
+- `resource://project/<id>/files/<path>` — файлы проекта из каталога `DATA_ROOT`.
+- `resource://pricebook/<region>` — прайс‑лист региона из каталога `RESOURCES_ROOT`.
+- `resource://catalog/materials` — общий каталог материалов.
+
+## Локальный запуск
+
+### Установка зависимостей
+
+```bash
 pip install -r requirements-core.txt
 pip install -r requirements-extras.txt
+```
+
+### Запуск
+
+```bash
+make dev      # режим разработки
+make run      # запуск без автоперезапуска
+```
+
+### Docker
+
+```bash
+docker compose up --build
+```
+
+## Тестирование
+
+```bash
 pytest -q
+```


### PR DESCRIPTION
## Summary
- expand root README with project overview, quick start, and test instructions
- document MCP Material Service features, resource URI scheme, and run options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a76ef1cd308322912569b7e467ac80