### PR TITLE
Add basic material substitution suggestions

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -12,6 +12,7 @@ from app.schemas.bom import (
     PriceBOMRequest,
     SuggestSubsRequest,
 )
+from app.services.substitutions import suggest_substitutions as subs_service
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
@@ -97,11 +98,12 @@ def price_bom(body: PriceBOMRequest):
 
 @router.post(
     "/suggest_substitutions",
-    responses={501: {"model": Error}},
     summary="Suggest alternates for gaps with constraints",
 )
 def suggest_substitutions(body: SuggestSubsRequest):
-    raise HTTPException(status_code=501, detail="Not implemented in step 0")
+    region = "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
+    payload = body.model_dump()
+    return subs_service(payload, region=region)
 
 
 app.include_router(router)

--- a/services/mcp-material/app/services/substitutions.py
+++ b/services/mcp-material/app/services/substitutions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+from app.schemas.bom import BOM, PricedBOM
+from app.services.pricebook import Pricebook
+
+def suggest_substitutions(payload: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Input payload may have:
+      - bom: BOM (optional)
+      - priced_bom: PricedBOM (optional)
+      - constraints: {"budget": "low"|"mid"|"high", "lead_time": "<=30d"|None}
+    Returns dict: {"alternatives": [{"for_code":..., "candidates":[...]}]}
+    """
+    pb = Pricebook(region=region)
+    pb.load()
+
+    bom: BOM | None = payload.get("bom")
+    priced: PricedBOM | None = payload.get("priced_bom")
+    constraints: Dict[str, Any] = payload.get("constraints") or {}
+
+    # choose gaps to cover
+    targets = []
+    if priced and priced.gaps:
+        for g in priced.gaps:
+            targets.append(g.item)
+    elif bom:
+        targets = bom.items
+    else:
+        return {"alternatives": []}
+
+    results: List[Dict[str, Any]] = []
+    price_list = [pb.get_by_code(c) for c in pb.codes()]
+    price_list = [p for p in price_list if p]
+
+    for it in targets:
+        canon = (it.name or "").lower()
+        cls = (it.props or {}).get("class")
+        # candidate filter
+        cand = []
+        for r in price_list:
+            rname = (r.name or "").lower()
+            if cls and cls in rname:
+                cand.append(r)
+            elif canon and canon.split()[0] in rname:
+                cand.append(r)
+        # constraints
+        budget = (constraints.get("budget") or "").lower()
+        if budget == "low":
+            cand = sorted(cand, key=lambda x: x.unit_price)
+        else:
+            cand = sorted(cand, key=lambda x: (x.lead_time_days or 9999, x.unit_price))
+
+        cand = cand[:3]
+        results.append({
+            "for_item": it.model_dump(),
+            "candidates": [
+                {
+                    "code": r.code, "name": r.name, "unit": r.unit,
+                    "unit_price": r.unit_price, "currency": r.currency,
+                    "lead_time_days": r.lead_time_days, "source": r.source
+                } for r in cand
+            ]
+        })
+
+    return {"alternatives": results}


### PR DESCRIPTION
## Summary
- implement suggestion service to propose cheaper/faster material alternatives
- expose `/suggest_substitutions` endpoint using the new service
- remove unused imports from substitution service

## Testing
- `cd services/mcp-material && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a778057ac48322a92e01cdc47ebd62