### PR TITLE
feat: add budget-aware substitution suggestions

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -13,6 +13,9 @@ from app.schemas.bom import (
 )
 from app.schemas.bom import PriceBOMRequest
 from app.services.pricing import price_bom as price_bom_service
+from app.services.substitutions import (
+    suggest_substitutions as suggest_substitutions_service,
+)
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
@@ -93,11 +96,15 @@ def price_bom(body: PriceBOMRequest):
 
 @router.post(
     "/suggest_substitutions",
-    responses={501: {"model": Error}},
     summary="Suggest alternates for gaps with constraints",
 )
 def suggest_substitutions(body: SuggestSubsRequest):
-    raise HTTPException(status_code=501, detail="Not implemented in step 0")
+    """Return substitution suggestions taking budget into account."""
+    budget = None
+    if body.constraints:
+        budget = body.constraints.get("budget")
+    suggestions = suggest_substitutions_service(budget)
+    return {"suggestions": suggestions}
 
 
 app.include_router(router)

--- a/services/mcp-material/app/services/substitutions.py
+++ b/services/mcp-material/app/services/substitutions.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Optional
+
+
+def suggest_substitutions(budget: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return demo substitution candidates adjusted for budget.
+
+    Budget handling:
+    * ``low`` (default) - return all candidates sorted by ascending price.
+    * ``mid`` - keep only mid-priced items (50-500) and sort ascending.
+    * ``high`` - prefer expensive items (>=200) sorted from most to least
+      expensive.
+
+    The function is intentionally simple and uses a static catalog so that
+    tests can exercise the sorting and filtering behaviour for each budget
+    level.
+    """
+    candidates: List[Dict[str, Any]] = [
+        {"code": "SUB-LOW", "name": "Budget Material", "unit_price": 10},
+        {"code": "SUB-MID-A", "name": "Standard Material A", "unit_price": 100},
+        {"code": "SUB-MID-B", "name": "Standard Material B", "unit_price": 200},
+        {"code": "SUB-HIGH", "name": "Premium Material", "unit_price": 1000},
+    ]
+    budget = (budget or "low").lower()
+    if budget == "mid":
+        filtered = [c for c in candidates if 50 <= c["unit_price"] <= 500]
+        return sorted(filtered, key=lambda c: c["unit_price"])
+    if budget == "high":
+        filtered = [c for c in candidates if c["unit_price"] >= 200]
+        return sorted(filtered, key=lambda c: c["unit_price"], reverse=True)
+    # default low-budget behaviour
+    return sorted(candidates, key=lambda c: c["unit_price"])

--- a/services/mcp-material/tests/test_suggest_substitutions.py
+++ b/services/mcp-material/tests/test_suggest_substitutions.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def _call(budget: str):
+    payload = {"constraints": {"budget": budget}}
+    return client.post("/mcp/material/suggest_substitutions", json=payload)
+
+
+def test_low_budget_returns_cheapest_first():
+    r = _call("low")
+    assert r.status_code == 200, r.text
+    js = r.json()
+    prices = [s["unit_price"] for s in js["suggestions"]]
+    # low budget keeps all items sorted ascending, so the first is the cheapest
+    assert prices == sorted(prices)
+    assert prices[0] == 10
+
+
+def test_mid_budget_filters_extremes_and_sorts_ascending():
+    r = _call("mid")
+    assert r.status_code == 200, r.text
+    js = r.json()
+    prices = [s["unit_price"] for s in js["suggestions"]]
+    # mid budget should drop the very cheap and very expensive options
+    assert prices == [100, 200]
+
+
+def test_high_budget_prefers_expensive_sorted_desc():
+    r = _call("high")
+    assert r.status_code == 200, r.text
+    js = r.json()
+    prices = [s["unit_price"] for s in js["suggestions"]]
+    # high budget returns expensive items first
+    assert prices == [1000, 200]


### PR DESCRIPTION
## Summary
- handle budget levels in `suggest_substitutions`
- document low/mid/high budget behaviors
- test budget-specific sorting and filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77d282e308322af75d0c50090c59a