### PR TITLE
Filter substitution results by lead time

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -13,6 +13,9 @@ from app.schemas.bom import (
 )
 from app.schemas.bom import PriceBOMRequest
 from app.services.pricing import price_bom as price_bom_service
+from app.services.substitutions import (
+    suggest_substitutions as suggest_substitutions_service,
+)
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
@@ -93,11 +96,13 @@ def price_bom(body: PriceBOMRequest):
 
 @router.post(
     "/suggest_substitutions",
-    responses={501: {"model": Error}},
     summary="Suggest alternates for gaps with constraints",
 )
 def suggest_substitutions(body: SuggestSubsRequest):
-    raise HTTPException(status_code=501, detail="Not implemented in step 0")
+    candidates = suggest_substitutions_service(
+        region="EU-Central", constraints=body.constraints
+    )
+    return {"candidates": candidates}
 
 
 app.include_router(router)

--- a/services/mcp-material/app/services/substitutions.py
+++ b/services/mcp-material/app/services/substitutions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Optional
+from dataclasses import asdict
+from app.services.pricebook import Pricebook, PriceRecord
+
+
+def _parse_lead_time(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if s.startswith("<="):
+        s = s[2:]
+    if s.endswith("d"):
+        s = s[:-1]
+    try:
+        return int(s)
+    except ValueError:
+        return None
+
+
+def suggest_substitutions(
+    region: str, constraints: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
+    pb = Pricebook(region=region)
+    candidates: List[PriceRecord] = []
+    for code in pb.codes():
+        rec = pb.get_by_code(code)
+        if rec:
+            candidates.append(rec)
+    # sort candidates by unit price then code for determinism
+    candidates.sort(key=lambda r: (r.unit_price, r.code))
+
+    limit = None
+    if constraints:
+        limit = _parse_lead_time(constraints.get("lead_time"))
+    if limit is not None:
+        candidates = [c for c in candidates if c.lead_time_days is None or c.lead_time_days <= limit]
+
+    return [asdict(c) for c in candidates]

--- a/services/mcp-material/resources/pricebook/EU-Central/pricebook.jsonl
+++ b/services/mcp-material/resources/pricebook/EU-Central/pricebook.jsonl
@@ -1,2 +1,3 @@
 {"code":"MAT-001","name":"Бетон C25/30","unit":"m3","unit_price":95.4,"currency":"EUR","lead_time_days":14,"updated":"2025-08-01"}
 {"code":"MAT-002","name":"Кирпич М150","unit":"m2","unit_price":12.1,"currency":"EUR","lead_time_days":7,"updated":"2025-08-01"}
+{"code":"MAT-003","name":"Сухая смесь","unit":"m3","unit_price":110.0,"currency":"EUR","lead_time_days":45,"updated":"2025-08-01"}

--- a/services/mcp-material/tests/test_suggest_substitutions.py
+++ b/services/mcp-material/tests/test_suggest_substitutions.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_suggest_substitutions_no_constraint():
+    r = client.post("/mcp/material/suggest_substitutions", json={})
+    assert r.status_code == 200, r.text
+    js = r.json()
+    codes = [c["code"] for c in js["candidates"]]
+    assert "MAT-003" in codes
+
+
+def test_suggest_substitutions_with_lead_time():
+    r = client.post(
+        "/mcp/material/suggest_substitutions",
+        json={"constraints": {"lead_time": "<=30d"}},
+    )
+    assert r.status_code == 200, r.text
+    js = r.json()
+    assert all(
+        c.get("lead_time_days") is None or c["lead_time_days"] <= 30
+        for c in js["candidates"]
+    )
+    codes = [c["code"] for c in js["candidates"]]
+    assert "MAT-003" not in codes


### PR DESCRIPTION
## Summary
- add substitutions service that sorts pricebook entries and filters by lead time constraint
- expose `/suggest_substitutions` endpoint and extend pricebook with high lead-time entry
- cover substitution requests with and without `lead_time` constraint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77d2a3ca08322a3a7bb3852ffa596