### PR TITLE
feat: add substitution suggestions service

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -14,7 +14,7 @@ from app.schemas.bom import (
 )
 from app.services.pricing import price_bom as price_bom_service
 from app.services.substitutions import (
-    suggest_substitutions as suggest_substitutions_service,
+    suggest_substitutions as subs_service,
 )
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
@@ -99,12 +99,9 @@ def price_bom(body: PriceBOMRequest):
     summary="Suggest alternates for gaps with constraints",
 )
 def suggest_substitutions(body: SuggestSubsRequest):
-    """Return substitution suggestions taking budget into account."""
-    budget = None
-    if body.constraints:
-        budget = body.constraints.get("budget")
-    suggestions = suggest_substitutions_service(budget)
-    return {"suggestions": suggestions}
+    region = "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
+    payload = body.model_dump()
+    return subs_service(payload, region=region)
 
 
 app.include_router(router)

--- a/services/mcp-material/app/services/substitutions.py
+++ b/services/mcp-material/app/services/substitutions.py
@@ -1,32 +1,72 @@
 from __future__ import annotations
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, List
+from app.schemas.bom import BOM, PricedBOM, Gap
+from app.services.pricebook import Pricebook
+from loguru import logger
 
 
-def suggest_substitutions(budget: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Return demo substitution candidates adjusted for budget.
-
-    Budget handling:
-    * ``low`` (default) - return all candidates sorted by ascending price.
-    * ``mid`` - keep only mid-priced items (50-500) and sort ascending.
-    * ``high`` - prefer expensive items (>=200) sorted from most to least
-      expensive.
-
-    The function is intentionally simple and uses a static catalog so that
-    tests can exercise the sorting and filtering behaviour for each budget
-    level.
+def suggest_substitutions(payload: Dict[str, Any], region: str) -> Dict[str, Any]:
     """
-    candidates: List[Dict[str, Any]] = [
-        {"code": "SUB-LOW", "name": "Budget Material", "unit_price": 10},
-        {"code": "SUB-MID-A", "name": "Standard Material A", "unit_price": 100},
-        {"code": "SUB-MID-B", "name": "Standard Material B", "unit_price": 200},
-        {"code": "SUB-HIGH", "name": "Premium Material", "unit_price": 1000},
-    ]
-    budget = (budget or "low").lower()
-    if budget == "mid":
-        filtered = [c for c in candidates if 50 <= c["unit_price"] <= 500]
-        return sorted(filtered, key=lambda c: c["unit_price"])
-    if budget == "high":
-        filtered = [c for c in candidates if c["unit_price"] >= 200]
-        return sorted(filtered, key=lambda c: c["unit_price"], reverse=True)
-    # default low-budget behaviour
-    return sorted(candidates, key=lambda c: c["unit_price"])
+    Input payload may have:
+      - bom: BOM (optional)
+      - priced_bom: PricedBOM (optional)
+      - constraints: {"budget": "low"|"mid"|"high", "lead_time": "<=30d"|None}
+    Returns dict: {"alternatives": [{"for_code":..., "candidates":[...]}]}
+    """
+    pb = Pricebook(region=region)
+    pb.load()
+
+    bom_data = payload.get("bom")
+    priced_data = payload.get("priced_bom")
+    bom: BOM | None = BOM.model_validate(bom_data) if bom_data else None
+    priced: PricedBOM | None = (
+        PricedBOM.model_validate(priced_data) if priced_data else None
+    )
+    constraints: Dict[str, Any] = payload.get("constraints") or {}
+
+    # choose gaps to cover
+    targets = []
+    if priced and priced.gaps:
+        for g in priced.gaps:
+            targets.append(g.item)
+    elif bom:
+        targets = bom.items
+    else:
+        return {"alternatives": []}
+
+    results: List[Dict[str, Any]] = []
+    price_list = [pb.get_by_code(c) for c in pb.codes()]
+    price_list = [p for p in price_list if p]
+
+    for it in targets:
+        canon = (it.name or "").lower()
+        cls = (it.props or {}).get("class")
+        # candidate filter
+        cand = []
+        for r in price_list:
+            rname = (r.name or "").lower()
+            if cls and cls in rname:
+                cand.append(r)
+            elif canon and canon.split()[0] in rname:
+                cand.append(r)
+        # constraints
+        budget = (constraints.get("budget") or "").lower()
+        if budget == "low":
+            cand = sorted(cand, key=lambda x: x.unit_price)
+        else:
+            cand = sorted(cand, key=lambda x: (x.lead_time_days or 9999, x.unit_price))
+
+        cand = cand[:3]
+        results.append({
+            "for_item": it.model_dump(),
+            "candidates": [
+                {
+                    "code": r.code, "name": r.name, "unit": r.unit,
+                    "unit_price": r.unit_price, "currency": r.currency,
+                    "lead_time_days": r.lead_time_days, "source": r.source
+                } for r in cand
+            ]
+        })
+
+    return {"alternatives": results}
+

--- a/services/mcp-material/tests/test_suggest_substitutions.py
+++ b/services/mcp-material/tests/test_suggest_substitutions.py
@@ -1,37 +1,28 @@
 from fastapi.testclient import TestClient
 from app.main import app
 
+
 client = TestClient(app)
 
 
-def _call(budget: str):
-    payload = {"constraints": {"budget": budget}}
-    return client.post("/mcp/material/suggest_substitutions", json=payload)
-
-
-def test_low_budget_returns_cheapest_first():
-    r = _call("low")
+def test_returns_substitutions_for_bom_items():
+    bom = {
+        "items": [
+            {"name": "Бетон C30", "unit": "m3", "qty": 10},
+            {"name": "Кирпич М200", "unit": "m2", "qty": 100},
+        ]
+    }
+    r = client.post("/mcp/material/suggest_substitutions", json={"bom": bom})
     assert r.status_code == 200, r.text
     js = r.json()
-    prices = [s["unit_price"] for s in js["suggestions"]]
-    # low budget keeps all items sorted ascending, so the first is the cheapest
-    assert prices == sorted(prices)
-    assert prices[0] == 10
+    assert "alternatives" in js
+    assert len(js["alternatives"]) == 2
+    codes = {
+        alt["candidates"][0]["code"]
+        for alt in js["alternatives"]
+        if alt.get("candidates")
+    }
+    assert codes == {"MAT-001", "MAT-002"}
+    for alt in js["alternatives"]:
+        assert len(alt["candidates"]) <= 3
 
-
-def test_mid_budget_filters_extremes_and_sorts_ascending():
-    r = _call("mid")
-    assert r.status_code == 200, r.text
-    js = r.json()
-    prices = [s["unit_price"] for s in js["suggestions"]]
-    # mid budget should drop the very cheap and very expensive options
-    assert prices == [100, 200]
-
-
-def test_high_budget_prefers_expensive_sorted_desc():
-    r = _call("high")
-    assert r.status_code == 200, r.text
-    js = r.json()
-    prices = [s["unit_price"] for s in js["suggestions"]]
-    # high budget returns expensive items first
-    assert prices == [1000, 200]


### PR DESCRIPTION
## Summary
- add substitution service that scans pricebook for cheaper or faster alternatives
- wire `/suggest_substitutions` endpoint to new service
- add tests for substitution suggestions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77f06d64c8322a3414ff0776ebbbd