### PR TITLE
Add project output path helpers and export request schemas

### DIFF
--- a/services/mcp-material/app/core/paths.py
+++ b/services/mcp-material/app/core/paths.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import Optional
+from .config import settings
+
+def project_files_root(project_id: str) -> Path:
+    base = settings.DATA_ROOT / "projects" / project_id / "files"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+def project_outputs_root(project_id: str) -> Path:
+    base = settings.DATA_ROOT / "projects" / project_id / "outputs"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+def ensure_parent(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path

--- a/services/mcp-material/app/schemas/bom.py
+++ b/services/mcp-material/app/schemas/bom.py
@@ -62,3 +62,19 @@ class SuggestSubsRequest(BaseModel):
     bom: Optional[BOM] = None
     priced_bom: Optional[PricedBOM] = None
     constraints: Optional[Dict[str, Any]] = None
+
+class ExportExcelRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    filename: str | None = None  # default: priced_bom.xlsx
+
+class ExportJsonRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    filename: str | None = None  # default: priced_bom.json
+
+class ReportPdfRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    title: str | None = "Сметный отчёт"
+    filename: str | None = None  # default: priced_bom.pdf


### PR DESCRIPTION
## Summary
- add project file/output path helpers
- support export schema requests for Excel, JSON, and PDF

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'reportlab')*


------
https://chatgpt.com/codex/tasks/task_e_68a785a417648322b1167b99db414b2f