### PR TITLE
Add BOM export endpoints and PDF reporting

### DIFF
--- a/services/mcp-material/app/core/paths.py
+++ b/services/mcp-material/app/core/paths.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from pathlib import Path
+from .config import settings
+
+
+def project_outputs_root(project_id: str) -> Path:
+    """Return path to outputs directory for a given project."""
+    return Path(settings.DATA_ROOT) / "projects" / project_id / "outputs"
+
+
+def ensure_parent(path: Path) -> None:
+    """Ensure that the parent directory of ``path`` exists."""
+    path.parent.mkdir(parents=True, exist_ok=True)

--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, APIRouter, HTTPException, Response
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
 from app.schemas.common import Health, Error
@@ -11,11 +11,16 @@ from app.schemas.bom import (
     ExtractBOMRequest,
     PriceBOMRequest,
     SuggestSubsRequest,
+    ExportExcelRequest,
+    ExportJsonRequest,
+    ReportPdfRequest,
 )
 from app.services.pricing import price_bom as price_bom_service
 from app.services.substitutions import (
     suggest_substitutions as subs_service,
 )
+from app.services.exporter import export_priced_bom_excel, export_priced_bom_json
+from app.services.report_pdf import generate_priced_bom_pdf
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
@@ -102,6 +107,24 @@ def suggest_substitutions(body: SuggestSubsRequest):
     region = "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
     payload = body.model_dump()
     return subs_service(payload, region=region)
+
+
+@router.post("/export/excel", summary="Export PricedBOM to Excel (.xlsx)")
+def export_excel(body: ExportExcelRequest):
+    path = export_priced_bom_excel(project_id=body.project_id, priced=body.priced_bom, filename=body.filename)
+    return FileResponse(path, media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", filename=path.name)
+
+
+@router.post("/export/json", summary="Export PricedBOM to JSON (.json)")
+def export_json(body: ExportJsonRequest):
+    path = export_priced_bom_json(project_id=body.project_id, priced=body.priced_bom, filename=body.filename)
+    return FileResponse(path, media_type="application/json", filename=path.name)
+
+
+@router.post("/report/pdf", summary="Generate simple PDF report from PricedBOM")
+def report_pdf(body: ReportPdfRequest):
+    path = generate_priced_bom_pdf(project_id=body.project_id, priced=body.priced_bom, title=body.title or "Сметный отчёт", filename=body.filename)
+    return FileResponse(path, media_type="application/pdf", filename=path.name)
 
 
 app.include_router(router)

--- a/services/mcp-material/app/schemas/bom.py
+++ b/services/mcp-material/app/schemas/bom.py
@@ -62,3 +62,22 @@ class SuggestSubsRequest(BaseModel):
     bom: Optional[BOM] = None
     priced_bom: Optional[PricedBOM] = None
     constraints: Optional[Dict[str, Any]] = None
+
+class ExportExcelRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    filename: Optional[str] = None
+
+
+class ExportJsonRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    filename: Optional[str] = None
+
+
+class ReportPdfRequest(BaseModel):
+    project_id: str
+    priced_bom: PricedBOM
+    title: Optional[str] = None
+    filename: Optional[str] = None
+

--- a/services/mcp-material/app/services/exporter.py
+++ b/services/mcp-material/app/services/exporter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Tuple
+import json
+import pandas as pd
+from app.schemas.bom import PricedBOM
+from app.core.paths import project_outputs_root, ensure_parent
+
+def export_priced_bom_excel(project_id: str, priced: PricedBOM, filename: str | None = None) -> Path:
+    out_dir = project_outputs_root(project_id)
+    name = filename or "priced_bom.xlsx"
+    path = out_dir / name
+
+    rows = []
+    for it in priced.items:
+        rows.append({
+            "code": it.code,
+            "name": it.name,
+            "unit": it.unit,
+            "qty": it.qty,
+            "unit_price": it.unit_price,
+            "currency": it.currency,
+            "lead_time_days": it.lead_time_days,
+            "price_source": it.price_source,
+        })
+    df_items = pd.DataFrame(rows)
+
+    gaps = []
+    for g in (priced.gaps or []):
+        gaps.append({
+            "reason": g.reason,
+            "item_name": g.item.name,
+            "item_unit": g.item.unit,
+            "item_qty": g.item.qty,
+            "detail": g.detail,
+        })
+    df_gaps = pd.DataFrame(gaps)
+
+    ensure_parent(path)
+    with pd.ExcelWriter(path) as xw:
+        df_items.to_excel(xw, index=False, sheet_name="Items")
+        df_gaps.to_excel(xw, index=False, sheet_name="Gaps")
+        # Summary sheet
+        pd.DataFrame([{
+            "subtotal": priced.subtotal,
+            "currency": priced.currency,
+            "items_count": len(priced.items),
+            "gaps_count": len(priced.gaps or []),
+        }]).to_excel(xw, index=False, sheet_name="Summary")
+    return path
+
+
+def export_priced_bom_json(project_id: str, priced: PricedBOM, filename: str | None = None) -> Path:
+    out_dir = project_outputs_root(project_id)
+    name = filename or "priced_bom.json"
+    path = out_dir / name
+    ensure_parent(path)
+    path.write_text(json.dumps(priced.model_dump(), ensure_ascii=False, indent=2), encoding="utf-8")
+    return path

--- a/services/mcp-material/app/services/report_pdf.py
+++ b/services/mcp-material/app/services/report_pdf.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from pathlib import Path
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import mm
+from app.schemas.bom import PricedBOM
+from app.core.paths import project_outputs_root, ensure_parent
+
+def generate_priced_bom_pdf(project_id: str, priced: PricedBOM, title: str = "Сметный отчёт", filename: str | None = None) -> Path:
+    out_dir = project_outputs_root(project_id)
+    name = filename or "priced_bom.pdf"
+    path = out_dir / name
+    ensure_parent(path)
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    w, h = A4
+
+    # Header
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(20*mm, (h - 20*mm), title)
+    c.setFont("Helvetica", 10)
+    c.drawString(20*mm, (h - 27*mm), f"Project: {project_id}")
+    c.drawString(20*mm, (h - 32*mm), f"Items: {len(priced.items)}  |  Gaps: {len(priced.gaps or [])}")
+
+    # Subtotal
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(20*mm, (h - 45*mm), f"Subtotal: {priced.subtotal} {priced.currency}")
+
+    # Top items table (first 12)
+    y = h - 60*mm
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(20*mm, y, "Позиции:")
+    y -= 6*mm
+    c.setFont("Helvetica", 9)
+    for it in priced.items[:12]:
+        line = f"- {it.name}  ({it.qty} {it.unit})  x {it.unit_price} {it.currency}"
+        c.drawString(22*mm, y, line)
+        y -= 5*mm
+        if y < 20*mm:
+            c.showPage(); y = h - 20*mm
+
+    # Gaps (first 6)
+    y -= 4*mm
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(20*mm, y, "Пробелы в прайсинге:")
+    y -= 6*mm
+    c.setFont("Helvetica", 9)
+    for g in (priced.gaps or [])[:6]:
+        line = f"- {g.reason}: {g.item.name} ({g.item.qty} {g.item.unit})"
+        c.drawString(22*mm, y, line)
+        y -= 5*mm
+        if y < 20*mm:
+            c.showPage(); y = h - 20*mm
+
+    c.showPage()
+    c.save()
+    return path


### PR DESCRIPTION
## Summary
- add utilities for project output paths
- export PricedBOM to Excel or JSON
- generate simple PDF report and expose new download endpoints

## Testing
- `cd services/mcp-material && make test`

------
https://chatgpt.com/codex/tasks/task_e_68a7862c80588322970f626c6811c787