### PR TITLE
Add tests for material export endpoints

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -11,10 +11,18 @@ from app.schemas.bom import (
     ExtractBOMRequest,
     PriceBOMRequest,
     SuggestSubsRequest,
+    ExportExcelRequest,
+    ExportJsonRequest,
+    ReportPdfRequest,
 )
 from app.services.pricing import price_bom as price_bom_service
 from app.services.substitutions import (
     suggest_substitutions as subs_service,
+)
+from app.services.export import (
+    export_excel as export_excel_service,
+    export_json as export_json_service,
+    report_pdf as report_pdf_service,
 )
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
@@ -102,6 +110,39 @@ def suggest_substitutions(body: SuggestSubsRequest):
     region = "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
     payload = body.model_dump()
     return subs_service(payload, region=region)
+
+
+@router.post("/export/excel")
+def export_excel(body: ExportExcelRequest):
+    content = export_excel_service(body.priced_bom)
+    filename = body.filename or "priced_bom.xlsx"
+    return Response(
+        content,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/export/json")
+def export_json(body: ExportJsonRequest):
+    content = export_json_service(body.priced_bom)
+    filename = body.filename or "priced_bom.json"
+    return Response(
+        content,
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/report/pdf")
+def report_pdf(body: ReportPdfRequest):
+    content = report_pdf_service(body.priced_bom, title=body.title or "Сметный отчёт")
+    filename = body.filename or "priced_bom.pdf"
+    return Response(
+        content,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 app.include_router(router)

--- a/services/mcp-material/app/services/export.py
+++ b/services/mcp-material/app/services/export.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import BytesIO
+import json
+import pandas as pd
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+from app.schemas.bom import PricedBOM
+
+
+def export_excel(priced_bom: PricedBOM) -> bytes:
+    df = pd.DataFrame([item.model_dump() for item in priced_bom.items])
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+    return buf.getvalue()
+
+
+def export_json(priced_bom: PricedBOM) -> bytes:
+    return json.dumps(priced_bom.model_dump(), ensure_ascii=False).encode("utf-8")
+
+
+def report_pdf(priced_bom: PricedBOM, title: str) -> bytes:
+    buf = BytesIO()
+    c = canvas.Canvas(buf, pagesize=A4)
+    width, height = A4
+    y = height - 40
+    c.setFont("Helvetica", 14)
+    c.drawString(40, y, title)
+    c.setFont("Helvetica", 10)
+    y -= 30
+    for it in priced_bom.items:
+        line = f"{it.name} ({it.unit}): {it.qty} x {it.unit_price} {it.currency}"
+        c.drawString(40, y, line)
+        y -= 15
+        if y < 40:
+            c.showPage()
+            c.setFont("Helvetica", 10)
+            y = height - 40
+    c.save()
+    return buf.getvalue()

--- a/services/mcp-material/tests/test_export.py
+++ b/services/mcp-material/tests/test_export.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+SAMPLE_PRICED = {
+    "items": [
+        {"name":"Бетон C25/30","unit":"m3","qty":12.5,"code":"MAT-001","unit_price":95.4,"currency":"EUR"},
+        {"name":"Кирпич М150","unit":"m2","qty":10.0,"code":"MAT-002","unit_price":12.1,"currency":"EUR"},
+    ],
+    "subtotal": 95.4*12.5 + 12.1*10.0,
+    "currency": "EUR",
+    "gaps": []
+}
+
+def test_export_excel(tmp_path, monkeypatch):
+    payload = {"project_id":"t1","priced_bom":SAMPLE_PRICED}
+    r = client.post("/mcp/material/export/excel", json=payload)
+    assert r.status_code == 200, r.text
+    assert "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" in r.headers.get("content-type","")
+
+def test_export_json(tmp_path, monkeypatch):
+    payload = {"project_id":"t1","priced_bom":SAMPLE_PRICED}
+    r = client.post("/mcp/material/export/json", json=payload)
+    assert r.status_code == 200, r.text
+    assert "application/json" in r.headers.get("content-type","")
+
+def test_report_pdf(tmp_path, monkeypatch):
+    payload = {"project_id":"t1","priced_bom":SAMPLE_PRICED, "title":"Отчёт (тест)"}
+    r = client.post("/mcp/material/report/pdf", json=payload)
+    assert r.status_code == 200, r.text
+    assert "application/pdf" in r.headers.get("content-type","")


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for exporting priced BOM to Excel, JSON, and PDF
- implement export helpers using pandas, openpyxl, and reportlab
- test excel, json, and pdf export responses

## Testing
- `pip install -r requirements-core.txt`
- `pip install -r requirements-extras.txt` *(partial: heavy dependencies)*
- `pip install pandas>=2.2 openpyxl>=3.1 reportlab>=4.2`
- `pip install httpx`
- `pip install pdfplumber`
- `pytest -q`
- `make dev`
- `curl -s -o /tmp/export.json -D - http://localhost:8080/mcp/material/export/json -H 'Content-Type: application/json' -d '{"project_id":"t1","priced_bom":{"items":[],"subtotal":0,"currency":"EUR","gaps":[]}}'`
- `curl -s -o /tmp/export.xlsx -D - http://localhost:8080/mcp/material/export/excel -H 'Content-Type: application/json' -d '{"project_id":"t1","priced_bom":{"items":[],"subtotal":0,"currency":"EUR","gaps":[]}}'`
- `curl -s -o /tmp/report.pdf -D - http://localhost:8080/mcp/material/report/pdf -H 'Content-Type: application/json' -d '{"project_id":"t1","priced_bom":{"items":[],"subtotal":0,"currency":"EUR","gaps":[]},"title":"t"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a78f14752c8322a44687ae6881b8a6