### PR TITLE
Add FAISS embeddings config and dependencies

### DIFF
--- a/services/mcp-material/app/core/config.py
+++ b/services/mcp-material/app/core/config.py
@@ -12,6 +12,12 @@ class Settings(BaseSettings):
     DATA_ROOT: Path = Field(default=Path("./data"))
     RESOURCES_ROOT: Path = Field(default=Path("./resources"))
 
+    CATALOG_MODEL_NAME: str = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+    CATALOG_TOPK: int = 10
+    CATALOG_MIN_SCORE: float = 0.55
+    CATALOG_INDEX_PATH: Path = Field(default=Path("./resources/catalog/materials.faiss"))
+    CATALOG_EMB_PATH: Path = Field(default=Path("./resources/catalog/materials.emb.jsonl"))
+
     class Config:
         env_file = ".env"
 

--- a/services/mcp-material/requirements-extras.txt
+++ b/services/mcp-material/requirements-extras.txt
@@ -11,3 +11,4 @@ ezdxf>=1.3
 pandas>=2.2
 openpyxl>=3.1
 reportlab>=4.2
+torch>=2.2 ; sys_platform != "darwin"


### PR DESCRIPTION
## Summary
- add FAISS and embeddings configuration settings for catalog search
- include torch dependency for embedding support

## Testing
- `cd services/mcp-material && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83c31a11083228417df28d27a4ea2