### PR TITLE
Add debug endpoint for catalog mapping

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -14,6 +14,8 @@ from app.schemas.bom import (
     ExportExcelRequest,
     ExportJsonRequest,
     ReportPdfRequest,
+    MapOneRequest,
+    MapOneResponse,
 )
 from app.services.pricing import price_bom as price_bom_service
 from app.services.substitutions import (
@@ -24,6 +26,7 @@ from app.services.export import (
     export_json as export_json_service,
     report_pdf as report_pdf_service,
 )
+from app.services.catalog import MaterialCatalog
 from app.core.resource_uri import ResourceUriResolver
 from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
@@ -147,6 +150,16 @@ def report_pdf(body: ReportPdfRequest):
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@router.post("/debug/map_one", response_model=MapOneResponse)
+def debug_map_one(body: MapOneRequest):
+    cat = MaterialCatalog()
+    cat.load()
+    row = cat.best_match(body.name)
+    if not row:
+        return MapOneResponse()
+    return MapOneResponse(code=row.code, canonical_name=row.canonical_name, score=None)
 
 
 app.include_router(router)

--- a/services/mcp-material/app/schemas/bom.py
+++ b/services/mcp-material/app/schemas/bom.py
@@ -78,3 +78,13 @@ class ReportPdfRequest(BaseModel):
     priced_bom: PricedBOM
     title: str | None = "Сметный отчёт"
     filename: str | None = None  # default: priced_bom.pdf
+
+
+class MapOneRequest(BaseModel):
+    name: str
+
+
+class MapOneResponse(BaseModel):
+    code: str | None = None
+    canonical_name: str | None = None
+    score: float | None = None


### PR DESCRIPTION
## Summary
- add MapOneRequest and MapOneResponse schemas for single-name mapping
- expose /debug/map_one to resolve a free-text material name via MaterialCatalog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a845ba28a08322831234638f4e64ef