### PR TITLE
chore: add prometheus client dependency

### DIFF
--- a/services/mcp-material/requirements-core.txt
+++ b/services/mcp-material/requirements-core.txt
@@ -7,3 +7,4 @@ orjson>=3.9
 loguru>=0.7
 python-multipart>=0.0.9
 httpx>=0.27
+prometheus-client>=0.20


### PR DESCRIPTION
## Summary
- add prometheus client to core requirements

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84ba5e64c83228198c5483e3e0922