### PR TITLE
Add parse row metrics

### DIFF
--- a/services/mcp-material/app/parsers/ifc_parser.py
+++ b/services/mcp-material/app/parsers/ifc_parser.py
@@ -7,6 +7,7 @@ except Exception:
     ifcopenshell = None
 
 from app.schemas.bom import RawSpec
+from app.core.metrics import PARSE_ROWS
 
 ELEMENT_CLASSES = [
     "IfcWall", "IfcSlab", "IfcDoor", "IfcWindow", "IfcColumn", "IfcBeam"
@@ -49,6 +50,7 @@ def parse_ifc_to_specs(ifc_path: Path) -> Dict[str, Any]:
                     source_table=f"{cls}",
                     extras={"GlobalId": getattr(el, "GlobalId", None)}
                 ))
+                PARSE_ROWS.labels(engine="ifc").inc()
         except Exception:
             continue
 

--- a/services/mcp-material/app/parsers/pdf_parser.py
+++ b/services/mcp-material/app/parsers/pdf_parser.py
@@ -11,6 +11,7 @@ except Exception:
 
 from .utils import canonical_header, normalize_unit, parse_number
 from app.schemas.bom import RawSpec
+from app.core.metrics import PARSE_ROWS
 
 
 def _plumber_tables(pdf_path: Path) -> List[Dict[str, Any]]:
@@ -124,6 +125,7 @@ def parse_pdf_to_specs(pdf_path: Path) -> Dict[str, Any]:
                         extras={"engine": t.get("engine"), "page": t.get("page")},
                     )
                 )
+                PARSE_ROWS.labels(engine=t.get("engine") or "pdfplumber").inc()
             except Exception:
                 # be robust: skip bad rows
                 continue


### PR DESCRIPTION
## Summary
- track parsed rows from PDF tables with metrics
- count rows from IFC parsing via metrics

## Testing
- `PYTHONPATH=services/mcp-material pytest` *(fails: FileNotFoundError: Pricebook not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8525494b883228db20c08aae9a937