### PR TITLE
Add quality metrics snapshot endpoint

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -36,6 +36,7 @@ from app.parsers.pdf_parser import parse_pdf_to_specs
 from app.parsers.ifc_parser import parse_ifc_to_specs
 from app.core.logging import setup_logging
 from app.services.normalization import map_to_catalog
+from app.services.quality import collect_metrics_snapshot
 
 logger = setup_logging()
 
@@ -84,6 +85,10 @@ def health():
 @app.get("/metrics")
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+@app.get("/quality", tags=["debug"], summary="Quality metrics snapshot (JSON)")
+def quality_snapshot():
+    return collect_metrics_snapshot()
 
 
 router = APIRouter(prefix="/mcp/material", tags=["mcp"])

--- a/services/mcp-material/app/services/quality.py
+++ b/services/mcp-material/app/services/quality.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from prometheus_client import REGISTRY
+from typing import Dict, Any
+
+def collect_metrics_snapshot() -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for metric in REGISTRY.collect():
+        mname = metric.name
+        samples = []
+        for s in metric.samples:
+            samples.append({
+                "name": s.name,
+                "labels": s.labels,
+                "value": s.value,
+            })
+        out[mname] = samples
+    return out
+


### PR DESCRIPTION
## Summary
- add helper to collect Prometheus metrics into a JSON snapshot
- expose `/quality` endpoint returning metrics snapshot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8558b75088322ac70fbc59dd14d71