### PR TITLE
feat: add audit logging for BOM pricing

### DIFF
--- a/services/mcp-material/app/core/audit.py
+++ b/services/mcp-material/app/core/audit.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+from datetime import datetime
+from app.core.paths import project_outputs_root
+
+
+def log_decision(project_id: str, kind: str, payload: dict) -> None:
+    """kind: 'parse'|'map'|'price'|'subs'"""
+    out_dir = project_outputs_root(project_id)
+    path = out_dir / "audit.log.jsonl"
+    rec = {"ts": datetime.utcnow().isoformat() + "Z", "kind": kind, **payload}
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -6,6 +6,7 @@ from time import perf_counter
 from fastapi import Request
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from app.core.metrics import REQUEST_LATENCY, REQUEST_COUNT
+from app.core.audit import log_decision
 from app.schemas.common import Health, Error
 from app.schemas.bom import (
     BOM,
@@ -86,6 +87,7 @@ def health():
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
+
 @app.get("/quality", tags=["debug"], summary="Quality metrics snapshot (JSON)")
 def quality_snapshot():
     return collect_metrics_snapshot()
@@ -129,7 +131,18 @@ def extract_bom(body: ExtractBOMRequest):
 
 @router.post("/price_bom", response_model=PricedBOM, summary="Apply regional pricebook to BOM")
 def price_bom(body: PriceBOMRequest):
-    return price_bom_service(body.bom, body.region, body.date)
+    result = price_bom_service(body.bom, body.region, body.date)
+    pid = getattr(body, "project_id", None) or "anonymous"
+    log_decision(
+        pid,
+        "price",
+        {
+            "subtotal": result.subtotal,
+            "priced": len(result.items),
+            "gaps": len(result.gaps or []),
+        },
+    )
+    return result
 
 
 @router.post(
@@ -137,7 +150,9 @@ def price_bom(body: PriceBOMRequest):
     summary="Suggest alternates for gaps with constraints",
 )
 def suggest_substitutions(body: SuggestSubsRequest):
-    region = "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
+    region = (
+        "EU-Central"  # for MVP we can infer from context later; or pass explicitly in constraints
+    )
     payload = body.model_dump()
     return subs_service(payload, region=region)
 


### PR DESCRIPTION
## Summary
- add lightweight audit logger
- log price_bom decisions with subtotal, priced count, and gap count

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a856a04e0083228f8ee236ce30ca6e