### PR TITLE
Add security middleware and IO endpoints to mcp-material service

### DIFF
--- a/services/mcp-material/CHANGELOG.md
+++ b/services/mcp-material/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+- add security middleware (API key, body/file limits, rate limit, timeout)
+- implement upload/download endpoints with path safety
+- persist exports under project outputs
+- add tests for security, ingest/download, semantic fallback
+- document environment variables

--- a/services/mcp-material/README.md
+++ b/services/mcp-material/README.md
@@ -2,13 +2,20 @@
 
 Сервис для извлечения спецификаций материалов из чертежей и расчёта стоимости.
 
-## Возможности
+## Endpoints
 
-- `GET /health` — проверка состояния сервиса.
-- `POST /mcp/material/parse_drawing` — конвертация PDF или IFC в список позиций.
-- `POST /mcp/material/extract_bom` — формирование нормализованной спецификации: объединение таблиц, распознавание заголовков, нормализация единиц и агрегация позиций.
-- `POST /mcp/material/price_bom` — оценка стоимости спецификации по региональному прайс‑листу.
-- `POST /mcp/material/suggest_substitutions` — подбор альтернативных материалов.
+- `GET /health` – сервис доступен.
+- `GET /metrics` – метрики Prometheus.
+- `GET /quality` – снимок внутренних метрик.
+- `POST /mcp/material/parse_drawing` – преобразование PDF/IFC в сырые позиции.
+- `POST /mcp/material/extract_bom` – нормализация спецификации.
+- `POST /mcp/material/price_bom` – применение прайс‑листа.
+- `POST /mcp/material/suggest_substitutions` – подбор альтернатив.
+- `POST /mcp/material/export/json` – экспорт сметы в JSON.
+- `POST /mcp/material/export/excel` – экспорт сметы в XLSX.
+- `POST /mcp/material/report/pdf` – PDF отчёт.
+- `POST /ingest/upload` – загрузка файлов проекта.
+- `GET /download/<project>/<kind>/<file>` – скачивание файлов.
 
 ## URI ресурсов
 
@@ -46,6 +53,17 @@ docker compose up --build
 pytest -q
 ```
 
+## Переменные окружения
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `API_KEY` | API ключ для защищённых эндпоинтов | `None` |
+| `MAX_REQUEST_BODY_MB` | максимальный размер тела запроса | `5` |
+| `MAX_FILE_SIZE_MB` | максимальный размер загружаемого файла | `5` |
+| `ALLOWED_EXTS` | разрешённые расширения для загрузки (через запятую) | `.pdf,.ifc` |
+| `REQUEST_TIMEOUT_SECONDS` | таймаут обработки запроса | `10` |
+| `RATE_LIMIT_RPS` | глобальное ограничение RPS | `50` |
+
 ## Step 3: Pricing
 Endpoints:
 - POST /mcp/material/price_bom
@@ -58,6 +76,6 @@ uvicorn app.main:app --host 0.0.0.0 --port 8080
 
 Example:
 curl -s http://localhost:8080/mcp/material/price_bom -X POST -H "Content-Type: application/json" -d '{
-  "bom":{"items":[{"name":"\u0411\u0435\u0442\u043e\u043d C25/30","unit":"m3","qty":12.5,"code":"MAT-001"}]},
+  "bom":{"items":[{"name":"Бетон C25/30","unit":"m3","qty":12.5,"code":"MAT-001"}]},
   "region":"EU-Central"
 }'

--- a/services/mcp-material/app/core/__init__.py
+++ b/services/mcp-material/app/core/__init__.py
@@ -1,0 +1,1 @@
+# core package

--- a/services/mcp-material/app/core/config.py
+++ b/services/mcp-material/app/core/config.py
@@ -12,6 +12,14 @@ class Settings(BaseSettings):
     DATA_ROOT: Path = Field(default=Path("./data"))
     RESOURCES_ROOT: Path = Field(default=Path("./resources"))
 
+    # Security / limits
+    API_KEY: str | None = None
+    MAX_REQUEST_BODY_MB: int = 5
+    MAX_FILE_SIZE_MB: int = 5
+    ALLOWED_EXTS: list[str] = Field(default_factory=lambda: [".pdf", ".ifc"])
+    REQUEST_TIMEOUT_SECONDS: int = 10
+    RATE_LIMIT_RPS: int = 50
+
     CATALOG_MODEL_NAME: str = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
     CATALOG_TOPK: int = 10
     CATALOG_MIN_SCORE: float = 0.55

--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -1,12 +1,15 @@
-from fastapi import FastAPI, APIRouter, HTTPException, Response
-from fastapi.responses import ORJSONResponse
+from fastapi import FastAPI, APIRouter, HTTPException, Response, UploadFile, File, Request
+from fastapi.responses import ORJSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
 from time import perf_counter
-from fastapi import Request
+import asyncio
+import mimetypes
+import time
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from app.core.metrics import REQUEST_LATENCY, REQUEST_COUNT
 from app.core.audit import log_decision
+from app.core.config import settings
 from app.schemas.common import Health, Error
 from app.schemas.bom import (
     BOM,
@@ -56,6 +59,46 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+SAFE_PATHS = {"/health", "/metrics", "/quality", "/docs", "/openapi.json"}
+_rate_state = {"ts": time.time(), "count": 0}
+
+
+@app.middleware("http")
+async def security_middleware(request: Request, call_next):
+    # Body size guard
+    max_body = settings.MAX_REQUEST_BODY_MB * 1024 * 1024
+    cl = request.headers.get("content-length")
+    if cl and int(cl) > max_body:
+        return Response(status_code=413)
+
+    # API key guard
+    if settings.API_KEY and request.url.path not in SAFE_PATHS:
+        if request.headers.get("x-api-key") != settings.API_KEY:
+            return Response(status_code=401)
+
+    # Rate limit (simple global counter per second)
+    rps = settings.RATE_LIMIT_RPS
+    if rps > 0:
+        now = time.time()
+        if now - _rate_state["ts"] >= 1:
+            _rate_state["ts"] = now
+            _rate_state["count"] = 0
+        if _rate_state["count"] >= rps:
+            return Response(status_code=429)
+        _rate_state["count"] += 1
+
+    # Execute with timeout
+    try:
+        response = await asyncio.wait_for(call_next(request), timeout=settings.REQUEST_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        return Response(status_code=504)
+
+    # Security headers
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("X-XSS-Protection", "1; mode=block")
+    return response
+
 
 @app.middleware("http")
 async def access_log(request: Request, call_next):
@@ -96,6 +139,45 @@ def quality_snapshot():
 router = APIRouter(prefix="/mcp/material", tags=["mcp"])
 
 resolver = ResourceUriResolver()
+
+
+@app.post("/ingest/upload", tags=["io"])
+async def ingest_upload(project_id: str, file: UploadFile = File(...)):
+    ext = Path(file.filename).suffix.lower()
+    if ext not in settings.ALLOWED_EXTS:
+        raise HTTPException(status_code=415, detail="Extension not allowed")
+    content = await file.read()
+    if len(content) > settings.MAX_FILE_SIZE_MB * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large")
+    safe_name = Path(file.filename).name
+    base = settings.DATA_ROOT / "projects" / project_id / "files"
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / safe_name
+    target.write_bytes(content)
+    uri = f"resource://project/{project_id}/files/{safe_name}"
+    return {"uri": uri}
+
+
+@app.get("/download/{project_id}/{kind}/{path:path}", tags=["io"])
+def download_file(project_id: str, kind: str, path: str):
+    if kind not in {"files", "outputs"}:
+        raise HTTPException(status_code=400, detail="Unsupported kind")
+    base = settings.DATA_ROOT / "projects" / project_id / kind
+    file_path = (base / path).resolve()
+    try:
+        file_path.relative_to(base.resolve())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Path escapes base")
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Not found")
+    mt, _ = mimetypes.guess_type(str(file_path))
+    return FileResponse(file_path, media_type=mt or "application/octet-stream")
+
+
+@app.get("/debug/slow", tags=["debug"])
+async def debug_slow():
+    await asyncio.sleep(settings.REQUEST_TIMEOUT_SECONDS + 1)
+    return {"status": "slow"}
 
 
 @router.post(
@@ -161,6 +243,9 @@ def suggest_substitutions(body: SuggestSubsRequest):
 def export_excel(body: ExportExcelRequest):
     content = export_excel_service(body.priced_bom)
     filename = body.filename or "priced_bom.xlsx"
+    out_dir = settings.DATA_ROOT / "projects" / body.project_id / "outputs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / filename).write_bytes(content)
     return Response(
         content,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -172,6 +257,9 @@ def export_excel(body: ExportExcelRequest):
 def export_json(body: ExportJsonRequest):
     content = export_json_service(body.priced_bom)
     filename = body.filename or "priced_bom.json"
+    out_dir = settings.DATA_ROOT / "projects" / body.project_id / "outputs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / filename).write_bytes(content)
     return Response(
         content,
         media_type="application/json",
@@ -183,6 +271,9 @@ def export_json(body: ExportJsonRequest):
 def report_pdf(body: ReportPdfRequest):
     content = report_pdf_service(body.priced_bom, title=body.title or "Сметный отчёт")
     filename = body.filename or "priced_bom.pdf"
+    out_dir = settings.DATA_ROOT / "projects" / body.project_id / "outputs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / filename).write_bytes(content)
     return Response(
         content,
         media_type="application/pdf",

--- a/services/mcp-material/app/parsers/__init__.py
+++ b/services/mcp-material/app/parsers/__init__.py
@@ -1,0 +1,1 @@
+# parsers package

--- a/services/mcp-material/app/schemas/__init__.py
+++ b/services/mcp-material/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+# schemas package

--- a/services/mcp-material/app/services/__init__.py
+++ b/services/mcp-material/app/services/__init__.py
@@ -1,0 +1,1 @@
+# services package

--- a/services/mcp-material/scripts/sanity_check.sh
+++ b/services/mcp-material/scripts/sanity_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+pip install -r requirements-core.txt -r requirements-extras.txt >/dev/null
+pytest -q
+uvicorn app.main:app --port 8090 --host 127.0.0.1 &
+PID=$!
+sleep 1
+curl -fsS http://127.0.0.1:8090/health >/dev/null
+curl -fsS http://127.0.0.1:8090/metrics >/dev/null
+curl -fsS http://127.0.0.1:8090/docs >/dev/null
+kill $PID
+echo "SANITY PASS"

--- a/services/mcp-material/tests/test_ingest_download.py
+++ b/services/mcp-material/tests/test_ingest_download.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_upload_and_download(tmp_path):
+    pid = "t1"
+    content = b"hello world"
+    r = client.post("/ingest/upload", params={"project_id": pid}, files={"file": ("spec.pdf", content, "application/pdf")})
+    assert r.status_code == 200, r.text
+    uri = r.json().get("uri")
+    assert uri == f"resource://project/{pid}/files/spec.pdf"
+    r2 = client.get(f"/download/{pid}/files/spec.pdf")
+    assert r2.status_code == 200
+    assert r2.content == content

--- a/services/mcp-material/tests/test_security.py
+++ b/services/mcp-material/tests/test_security.py
@@ -1,0 +1,45 @@
+from fastapi.testclient import TestClient
+from app.main import app, _rate_state
+from app.core import config
+
+client = TestClient(app)
+
+
+def test_disallowed_extension(tmp_path):
+    content = b"data"
+    r = client.post("/ingest/upload", params={"project_id": "p1"}, files={"file": ("evil.exe", content, "application/octet-stream")})
+    assert r.status_code == 415
+
+
+def test_oversize_file(monkeypatch):
+    monkeypatch.setattr(config.settings, "MAX_FILE_SIZE_MB", 0)
+    content = b"a" * 10
+    r = client.post("/ingest/upload", params={"project_id": "p1"}, files={"file": ("spec.pdf", content, "application/pdf")})
+    assert r.status_code == 413
+
+
+def test_request_body_limit(monkeypatch):
+    monkeypatch.setattr(config.settings, "MAX_REQUEST_BODY_MB", 0)
+    big = "x" * 10
+    r = client.post("/mcp/material/price_bom", data=big, headers={"content-type": "application/json"})
+    assert r.status_code == 413
+
+
+def test_api_key_required(monkeypatch):
+    monkeypatch.setattr(config.settings, "API_KEY", "secret")
+    r = client.post("/mcp/material/price_bom", json={"bom":{"items":[]},"region":"EU-Central"})
+    assert r.status_code == 401
+
+
+def test_rate_limit(monkeypatch):
+    monkeypatch.setattr(config.settings, "RATE_LIMIT_RPS", 1)
+    _rate_state["ts"] = 0
+    client.get("/health")
+    r = client.get("/health")
+    assert r.status_code == 429
+
+
+def test_request_timeout(monkeypatch):
+    monkeypatch.setattr(config.settings, "REQUEST_TIMEOUT_SECONDS", 0)
+    r = client.get("/debug/slow")
+    assert r.status_code == 504

--- a/services/mcp-material/tests/test_semantic_fallback.py
+++ b/services/mcp-material/tests/test_semantic_fallback.py
@@ -1,0 +1,9 @@
+from app.services.catalog import MaterialCatalog
+
+
+def test_semantic_fallback(monkeypatch):
+    monkeypatch.setattr('app.services.catalog.HAS_EMB', False)
+    cat = MaterialCatalog()
+    # should load without embeddings and not crash
+    cat.load()
+    assert cat.match("бетон") == []


### PR DESCRIPTION
## Summary
- protect API with security middleware (API key, size limits, rate limit, timeout, security headers)
- add upload/download endpoints and persist exports under project outputs
- document environment variables and add sanity script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a859c8232c83228f51a747adf03dc2