### PR TITLE
chore: update material service limits

### DIFF
--- a/services/mcp-material/README.md
+++ b/services/mcp-material/README.md
@@ -58,11 +58,11 @@ pytest -q
 | Name | Description | Default |
 | ---- | ----------- | ------- |
 | `API_KEY` | API ключ для защищённых эндпоинтов | `None` |
-| `MAX_REQUEST_BODY_MB` | максимальный размер тела запроса | `5` |
-| `MAX_FILE_SIZE_MB` | максимальный размер загружаемого файла | `5` |
-| `ALLOWED_EXTS` | разрешённые расширения для загрузки (через запятую) | `.pdf,.ifc` |
-| `REQUEST_TIMEOUT_SECONDS` | таймаут обработки запроса | `10` |
-| `RATE_LIMIT_RPS` | глобальное ограничение RPS | `50` |
+| `MAX_REQUEST_BODY_MB` | максимальный размер тела запроса | `20` |
+| `MAX_FILE_SIZE_MB` | максимальный размер загружаемого файла | `50` |
+| `ALLOWED_EXTS` | разрешённые расширения для загрузки (через запятую) | `.pdf,.ifc,.dwg` |
+| `REQUEST_TIMEOUT_SECONDS` | таймаут обработки запроса | `30.0` |
+| `RATE_LIMIT_RPS` | глобальное ограничение RPS | `5.0` |
 
 ## Step 3: Pricing
 Endpoints:

--- a/services/mcp-material/app/core/config.py
+++ b/services/mcp-material/app/core/config.py
@@ -13,12 +13,12 @@ class Settings(BaseSettings):
     RESOURCES_ROOT: Path = Field(default=Path("./resources"))
 
     # Security / limits
-    API_KEY: str | None = None
-    MAX_REQUEST_BODY_MB: int = 5
-    MAX_FILE_SIZE_MB: int = 5
-    ALLOWED_EXTS: list[str] = Field(default_factory=lambda: [".pdf", ".ifc"])
-    REQUEST_TIMEOUT_SECONDS: int = 10
-    RATE_LIMIT_RPS: int = 50
+    API_KEY: str | None = None  # set in env to enable auth
+    MAX_REQUEST_BODY_MB: int = 20
+    MAX_FILE_SIZE_MB: int = 50
+    ALLOWED_EXTS: tuple[str, ...] = (".pdf", ".ifc", ".dwg")
+    REQUEST_TIMEOUT_SECONDS: float = 30.0
+    RATE_LIMIT_RPS: float = 5.0  # per-process simple limiter
 
     CATALOG_MODEL_NAME: str = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
     CATALOG_TOPK: int = 10


### PR DESCRIPTION
## Summary
- increase request body and file size limits
- expand allowed file extensions and adjust request timeout
- document new settings

## Testing
- `pytest -q` *(fails: 10 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a866d65c4483228bf7d178d3b53f90