### PR TITLE
Validate extension and size before parsing drawings

### DIFF
--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -216,9 +216,20 @@ async def debug_slow():
 )
 def parse_drawing(body: ParseDrawingRequest):
     path: Path = resolver.resolve(body.file_uri)
-    if not path.exists():
-        raise HTTPException(status_code=404, detail="File not found")
+    # Validate extension
     suffix = path.suffix.lower()
+    if suffix not in settings.ALLOWED_EXTS:
+        raise HTTPException(status_code=415, detail=f"Extension not allowed: {suffix}")
+    # Validate file size
+    try:
+        size_mb = path.stat().st_size / (1024 * 1024)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="File not found")
+    if size_mb > settings.MAX_FILE_SIZE_MB:
+        raise HTTPException(
+            status_code=413,
+            detail=(f"File too large: {size_mb:.1f} MB > {settings.MAX_FILE_SIZE_MB} MB"),
+        )
     if suffix == ".pdf":
         return parse_pdf_to_specs(path)
     if suffix == ".ifc":


### PR DESCRIPTION
## Summary
- ensure drawing parser checks allowed extensions
- enforce maximum file size before parsing

## Testing
- `black app/main.py`
- `ruff check app/main.py` *(fails: F841 local variable `e` assigned but unused)*
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a869578b008322867bbc8653a7d270