### PR TITLE
Fix material catalog resilience and request size handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 - Add missing `httpx` dependency and gracefully fallback when embedding model
   is unavailable, allowing tests to run without network access.
+- Handle missing `numpy` gracefully in material catalog and reorder security
+  middleware to return HTTP 413 before rate limiting.

--- a/services/mcp-material/CHANGELOG.md
+++ b/services/mcp-material/CHANGELOG.md
@@ -6,3 +6,6 @@
 - persist exports under project outputs
 - add tests for security, ingest/download, semantic fallback
 - document environment variables
+- make ``numpy`` optional in catalog to avoid import errors when embeddings are
+  unavailable
+- ensure oversized requests return 413 before hitting rate limits

--- a/services/mcp-material/app/main.py
+++ b/services/mcp-material/app/main.py
@@ -93,21 +93,6 @@ async def security_headers(request: Request, call_next):
     return response
 
 
-@app.middleware("http")
-async def body_size_limit(request: Request, call_next):
-    max_bytes = settings.MAX_REQUEST_BODY_MB * 1024 * 1024
-    if request.method in ("POST", "PUT", "PATCH"):
-        body = await request.body()
-        if len(body) > max_bytes:
-            return PlainTextResponse("Request entity too large", status_code=413)
-
-        async def receive_gen():
-            return {"type": "http.request", "body": body, "more_body": False}
-
-        request._receive = receive_gen
-    return await call_next(request)
-
-
 _RATE_WINDOW = 1.0
 _LAST_HITS = {}
 _rate_state = {"ts": 0}
@@ -170,6 +155,27 @@ async def access_log(request: Request, call_next):
         REQUEST_LATENCY.labels(method=method, path=path, status=status).observe(dur)
         REQUEST_COUNT.labels(method=method, path=path, status=status).inc()
         logger.info(f"{method} {path} -> {status} in {dur:.3f}s")
+
+
+@app.middleware("http")
+async def body_size_limit(request: Request, call_next):
+    """Reject requests with bodies exceeding configured size.
+
+    The middleware is defined last so that it runs *first* in the Starlette
+    middleware stack, ensuring that oversize requests are rejected before they
+    hit rate limiting or other guards.
+    """
+    max_bytes = settings.MAX_REQUEST_BODY_MB * 1024 * 1024
+    if request.method in ("POST", "PUT", "PATCH"):
+        body = await request.body()
+        if len(body) > max_bytes:
+            return PlainTextResponse("Request entity too large", status_code=413)
+
+        async def receive_gen():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        request._receive = receive_gen
+    return await call_next(request)
 
 
 @app.get("/health", response_model=Health, tags=["health"], summary="Health check")

--- a/services/mcp-material/app/services/catalog.py
+++ b/services/mcp-material/app/services/catalog.py
@@ -4,8 +4,25 @@ from typing import List, Dict, Tuple, Optional
 import json
 import os
 from dataclasses import dataclass
-import numpy as np
 from loguru import logger
+
+# ``numpy`` is used only when the optional semantic-search stack is available.
+#
+# In the minimal execution environment used for the tests the heavy numerical
+# dependency might be missing which would raise ``ModuleNotFoundError`` during
+# module import and prevent the service from starting.  Previously the import
+# happened unconditionally which meant that even when tests explicitly disabled
+# embeddings (by monkeypatching ``HAS_EMB``) the import failure short-circuited
+# everything.
+#
+# To make the catalogue robust we attempt to import ``numpy`` lazily and fall
+# back to ``None`` when it isn't installed.  The rest of the code checks for the
+# presence of ``np`` before accessing it which allows the service to operate in a
+# degraded, fuzzy‑matching‑only mode.
+try:  # pragma: no cover - exercised indirectly
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover
+    np = None  # type: ignore
 
 from app.core.config import settings
 from app.core.resource_uri import ResourceUriResolver
@@ -13,8 +30,12 @@ from app.core.resource_uri import ResourceUriResolver
 try:
     from sentence_transformers import SentenceTransformer
     import faiss
-    HAS_EMB = True
-except Exception:
+    HAS_EMB = np is not None  # require numpy as well
+except Exception:  # pragma: no cover - optional dependencies
+    HAS_EMB = False
+
+if np is None:
+    # Ensure the flag is coherent when numpy isn't available
     HAS_EMB = False
 
 @dataclass


### PR DESCRIPTION
## Summary
- guard `numpy` import in material catalog so service runs without heavy deps
- run body-size middleware before rate limiter to respond with HTTP 413

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a878f0f4948322b797dc22444bc66f