### PR TITLE
Add orchestrator service configuration

### DIFF
--- a/services/orchestrator/.env.example
+++ b/services/orchestrator/.env.example
@@ -1,0 +1,3 @@
+MCP_BASE_URL=http://localhost:8080
+MCP_API_KEY=
+MCP_REGION=EU-Central

--- a/services/orchestrator/pyproject.toml
+++ b/services/orchestrator/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aec-orchestrator"
+version = "0.0.1"
+requires-python = ">=3.11"

--- a/services/orchestrator/requirements.txt
+++ b/services/orchestrator/requirements.txt
@@ -1,0 +1,8 @@
+langchain>=0.2
+langgraph>=0.2
+httpx>=0.27
+pydantic>=2.7
+pydantic-settings>=2.3
+tenacity>=8.2
+python-dotenv>=1.0
+orjson>=3.9


### PR DESCRIPTION
## Summary
- add pyproject, requirements, and environment example for orchestrator service

## Testing
- `pytest services/orchestrator/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8819f2d48832285d45f2e8a58c469