### PR TITLE
Add orchestrator settings configuration

### DIFF
--- a/services/orchestrator/app/config.py
+++ b/services/orchestrator/app/config.py
@@ -1,0 +1,14 @@
+from pydantic_settings import BaseSettings
+from pydantic import Field, AnyUrl
+
+class Settings(BaseSettings):
+    MCP_BASE_URL: AnyUrl = "http://localhost:8080"
+    MCP_API_KEY: str | None = None
+    MCP_REGION: str = "EU-Central"
+    REQUEST_TIMEOUT: float = 30.0
+    RETRIES: int = 3
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add Pydantic settings for orchestrator service configuration

## Testing
- `pytest services/orchestrator`

------
https://chatgpt.com/codex/tasks/task_e_68a8828dfb288322a9dfd99f2aae27dc