### PR TITLE
feat: add HTTP client for orchestrator

### DIFF
--- a/services/orchestrator/app/client.py
+++ b/services/orchestrator/app/client.py
@@ -1,0 +1,12 @@
+import httpx
+from .config import settings
+
+def mcp_client() -> httpx.Client:
+    headers = {}
+    if settings.MCP_API_KEY:
+        headers["x-api-key"] = settings.MCP_API_KEY
+    return httpx.Client(
+        base_url=str(settings.MCP_BASE_URL),
+        headers=headers,
+        timeout=settings.REQUEST_TIMEOUT,
+    )


### PR DESCRIPTION
## Summary
- add reusable HTTPX client for orchestrator service

## Testing
- `pip install -r requirements.txt`
- `pip install fastapi`
- `pip install python-multipart`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8834c4d3c8322a157d6905c5d4547