### PR TITLE
Add MCP client factory using httpx

### DIFF
--- a/services/orchestrator/app/client.py
+++ b/services/orchestrator/app/client.py
@@ -1,0 +1,12 @@
+import httpx
+from .config import settings
+
+def mcp_client() -> httpx.Client:
+    headers = {}
+    if settings.MCP_API_KEY:
+        headers["x-api-key"] = settings.MCP_API_KEY
+    return httpx.Client(
+        base_url=str(settings.MCP_BASE_URL),
+        headers=headers,
+        timeout=settings.REQUEST_TIMEOUT,
+    )


### PR DESCRIPTION
## Summary
- add httpx-based MCP client that injects optional API key, base URL, and timeout from settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a887fb276c8322afe7645205ef37d9