### PR TITLE
Add PipelineState model to orchestrator

### DIFF
--- a/services/orchestrator/app/state.py
+++ b/services/orchestrator/app/state.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Optional
+
+class PipelineState(BaseModel):
+    project_id: str
+    file_uri: str
+    region: str = "EU-Central"
+
+    parsed: Optional[Dict[str, Any]] = None
+    bom: Optional[Dict[str, Any]] = None
+    priced: Optional[Dict[str, Any]] = None
+    subs: Optional[Dict[str, Any]] = None
+
+    export_json_path: Optional[str] = None
+    export_xlsx_path: Optional[str] = None
+    report_pdf_path: Optional[str] = None
+
+    errors: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- add PipelineState pydantic model for tracking pipeline state and artifacts

## Testing
- `pytest services/orchestrator/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a88cb6d3888322a89a352a8b01a2d5