### PR TITLE
feat(orchestrator): add basic web UI

### DIFF
--- a/services/orchestrator/app/main.py
+++ b/services/orchestrator/app/main.py
@@ -1,8 +1,29 @@
-from fastapi import FastAPI, UploadFile, File
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from typing import List, Dict
+
 
 app = FastAPI(title="MCP Orchestrator", version="0.0.1")
+
+# Enable permissive CORS so the simple HTML client can access the API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Resolve the path to the static directory relative to this file
+STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+
+# Serve static assets (like the index.html) from /static
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 class RunRequest(BaseModel):
@@ -11,6 +32,12 @@ class RunRequest(BaseModel):
 
 class ChatRequest(BaseModel):
     message: str
+
+
+@app.get("/")
+async def index() -> FileResponse:  # pragma: no cover - simple static file
+    """Serve the minimal HTML client."""
+    return FileResponse(STATIC_DIR / "index.html")
 
 
 @app.get("/health")

--- a/services/orchestrator/static/index.html
+++ b/services/orchestrator/static/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>MCP Orchestrator</title>
+</head>
+<body>
+  <h1>MCP Orchestrator</h1>
+  <form id="run-form">
+    <label>
+      Project ID: <input type="text" name="project_id" required />
+    </label><br />
+    <label>
+      Region:
+      <select name="region">
+        <option value="eu-central">EU-Central</option>
+        <option value="ru-moscow">RU-Moscow</option>
+      </select>
+    </label><br />
+    <label>
+      File: <input type="file" name="file" accept=".pdf,.ifc" required />
+    </label><br />
+    <button type="submit">Submit</button>
+  </form>
+
+  <h2>Artifact Links</h2>
+  <div id="links"></div>
+  <h2>Priced Preview</h2>
+  <pre id="preview"></pre>
+
+  <script>
+    document.getElementById('run-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(e.target);
+      try {
+        const response = await fetch('/run_multipart', {
+          method: 'POST',
+          body: formData
+        });
+        const data = await response.json();
+
+        const linksDiv = document.getElementById('links');
+        linksDiv.innerHTML = '';
+        if (data.artifact_urls) {
+          data.artifact_urls.forEach(url => {
+            const a = document.createElement('a');
+            a.href = url;
+            a.textContent = url;
+            a.target = '_blank';
+            linksDiv.appendChild(a);
+            linksDiv.appendChild(document.createElement('br'));
+          });
+        }
+
+        const preview = document.getElementById('preview');
+        if (data.priced_preview) {
+          preview.textContent = JSON.stringify(data.priced_preview, null, 2);
+        } else {
+          preview.textContent = JSON.stringify(data, null, 2);
+        }
+      } catch (err) {
+        alert('Request failed: ' + err);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static HTML client and add CORS in orchestrator service
- provide simple form to upload project details and send to `/run_multipart`

## Testing
- `pytest -q services/orchestrator/tests/test_api.py`
- `pytest -q` *(fails: No module named 'app' in other services)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f4c2f84832282e24dd0db8f9162