### PR TITLE
feat: include artifact URLs in orchestrator responses

### DIFF
--- a/services/orchestrator/app/main.py
+++ b/services/orchestrator/app/main.py
@@ -1,11 +1,14 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Any
+import os
 
 from fastapi import FastAPI, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+
+from .config import settings
 
 
 app = FastAPI(title="MCP Orchestrator", version="0.0.1")
@@ -27,7 +30,9 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 class RunRequest(BaseModel):
-    steps: List[Dict] = []
+    project_id: str
+    priced_bom: Dict[str, Any] = {}
+    filenames: Dict[str, str] = {}
 
 
 class ChatRequest(BaseModel):
@@ -45,15 +50,31 @@ async def health() -> Dict[str, str]:
     return {"status": "ok"}
 
 
+def _build_artifacts(project_id: str, filenames: Dict[str, str]) -> Dict[str, str]:
+    base = str(settings.MCP_BASE_URL).rstrip("/")
+    artifacts: Dict[str, str] = {}
+    for kind, name in filenames.items():
+        artifacts[f"{kind}_url"] = f"{base}/mcp/material/download/{project_id}/outputs/{name}"
+    return artifacts
+
+
 @app.post("/run")
-async def run(req: RunRequest) -> Dict[str, List[Dict]]:  # pragma: no cover - trivial
-    return {"steps": req.steps}
+async def run(req: RunRequest) -> Dict[str, Any]:
+    artifacts = _build_artifacts(req.project_id, req.filenames)
+    return {"priced_bom": req.priced_bom, "artifacts": artifacts}
 
 
 @app.post("/run_multipart")
-async def run_multipart(file: UploadFile = File(...)) -> Dict[str, str]:
-    data = await file.read()
-    return {"filename": file.filename, "size": str(len(data))}
+async def run_multipart(project_id: str, file: UploadFile = File(...)) -> Dict[str, Any]:
+    _ = await file.read()
+    base_name, _ = os.path.splitext(file.filename)
+    filenames = {
+        "excel": f"{base_name}.xlsx",
+        "json": f"{base_name}.json",
+        "pdf": f"{base_name}.pdf",
+    }
+    artifacts = _build_artifacts(project_id, filenames)
+    return {"priced_bom": {}, "artifacts": artifacts}
 
 
 @app.post("/chat")

--- a/services/orchestrator/tests/test_api.py
+++ b/services/orchestrator/tests/test_api.py
@@ -11,15 +11,37 @@ def test_health():
 
 
 def test_run():
-    r = client.post("/run", json={"steps": []})
+    payload = {
+        "project_id": "123",
+        "priced_bom": {"total": 1},
+        "filenames": {
+            "excel": "bom.xlsx",
+            "json": "bom.json",
+            "pdf": "bom.pdf",
+        },
+    }
+    r = client.post("/run", json=payload)
     assert r.status_code == 200
-    assert "steps" in r.json()
+    js = r.json()
+    assert js["priced_bom"]["total"] == 1
+    base = "http://localhost:8080"
+    assert js["artifacts"]["excel_url"] == f"{base}/mcp/material/download/123/outputs/bom.xlsx"
+    assert js["artifacts"]["json_url"] == f"{base}/mcp/material/download/123/outputs/bom.json"
+    assert js["artifacts"]["pdf_url"] == f"{base}/mcp/material/download/123/outputs/bom.pdf"
 
 
 def test_run_multipart():
-    r = client.post("/run_multipart", files={"file": ("test.txt", b"hello", "text/plain")})
+    r = client.post(
+        "/run_multipart",
+        params={"project_id": "xyz"},
+        files={"file": ("test.txt", b"hello", "text/plain")},
+    )
     assert r.status_code == 200
-    assert r.json()["filename"] == "test.txt"
+    js = r.json()
+    base = "http://localhost:8080"
+    assert js["artifacts"]["excel_url"] == f"{base}/mcp/material/download/xyz/outputs/test.xlsx"
+    assert js["artifacts"]["json_url"] == f"{base}/mcp/material/download/xyz/outputs/test.json"
+    assert js["artifacts"]["pdf_url"] == f"{base}/mcp/material/download/xyz/outputs/test.pdf"
 
 
 def test_chat():


### PR DESCRIPTION
## Summary
- include project artifact download URLs in `/run` and `/run_multipart` responses
- test URLs for JSON, Excel, and PDF artifacts

## Testing
- `pip install fastapi==0.111.0 uvicorn==0.30.1`
- `pip install pydantic-settings==2.3.0`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a890371b708322a55d33c2c10d9501