### PR TITLE
feat: add LLM agent with tool-calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+**/.env
+**/.env.local

--- a/services/orchestrator/.env.example
+++ b/services/orchestrator/.env.example
@@ -1,3 +1,6 @@
 MCP_BASE_URL=http://localhost:8080
 MCP_API_KEY=
 MCP_REGION=EU-Central
+LLM_PROVIDER=openai
+LLM_MODEL=gpt-4o-mini
+OPENAI_API_KEY=

--- a/services/orchestrator/Makefile
+++ b/services/orchestrator/Makefile
@@ -1,0 +1,5 @@
+.PHONY: dev agent
+dev:
+	uvicorn app.server:app --host 0.0.0.0 --port 8090 --reload
+agent:
+	uvicorn app.chat_server:app --host 0.0.0.0 --port 8091 --reload

--- a/services/orchestrator/README.md
+++ b/services/orchestrator/README.md
@@ -18,3 +18,15 @@ curl -X POST "http://localhost:8090/run" -H "Content-Type: application/json" -d 
 ```bash
 curl -X POST "http://localhost:8090/run_multipart" -F "file=@./sample.txt"
 ```
+
+- **LLM Agent (Step 9)**:
+  - Set `OPENAI_API_KEY` in env (do NOT commit keys).
+  - Run HTTP agent server:
+    ```
+    export OPENAI_API_KEY=*** 
+    cd services/orchestrator
+    pip install -r requirements.txt
+    make agent   # http://localhost:8091
+    curl -s -X POST http://localhost:8091/chat -H "Content-Type: application/json" -d '{"message":"Сделай смету из resource://project/demo/files/spec.pdf и отдай PDF/Excel"}'
+    ```
+  - Local fallback: set `LLM_PROVIDER=local` and `LOCAL_LLM_BASE_URL=http://localhost:8000/v1`.

--- a/services/orchestrator/app/agent.py
+++ b/services/orchestrator/app/agent.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from langchain.agents import initialize_agent, AgentType
+from langchain.prompts import MessagesPlaceholder
+from langchain.schema import SystemMessage
+from langchain.memory import ConversationBufferMemory
+from .llm import build_llm
+from .tools import parse_tool, extract_tool, price_tool, subs_tool, export_tool
+
+SYSTEM_PROMPT = """Ты — AEC Copilot. Шаги:
+1) parse_drawing(file_uri)
+2) extract_bom(scope={'specs': ...} если parse вернул specs)
+3) price_bom(bom, region)
+4) suggest_substitutions(priced_bom) — опционально
+5) export_results(project_id, priced_bom, filename_prefix='report')
+Всегда возвращай пути к артефактам, если они получены."""
+
+def build_agent():
+    llm = build_llm()
+    tools = [parse_tool, extract_tool, price_tool, subs_tool, export_tool]
+    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+    agent = initialize_agent(
+        tools=tools,
+        llm=llm,
+        agent=AgentType.OPENAI_FUNCTIONS,
+        verbose=False,
+        max_iterations=8,
+        early_stopping_method="generate",
+        memory=memory,
+    )
+    agent.agent_kwargs = agent.agent_kwargs or {}
+    agent.agent_kwargs["extra_prompt_messages"] = [SystemMessage(content=SYSTEM_PROMPT), MessagesPlaceholder(variable_name="chat_history")]
+    return agent

--- a/services/orchestrator/app/chat_cli.py
+++ b/services/orchestrator/app/chat_cli.py
@@ -1,0 +1,12 @@
+import argparse, sys
+from .agent import build_agent
+
+def main():
+    p = argparse.ArgumentParser(description="AEC Agent CLI")
+    p.add_argument("--prompt", default="Сделай смету из resource://project/demo/files/spec.pdf и отдай PDF")
+    args = p.parse_args()
+    agent = build_agent()
+    print(agent.run(args.prompt))
+
+if __name__ == "__main__":
+    main()

--- a/services/orchestrator/app/chat_server.py
+++ b/services/orchestrator/app/chat_server.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from .agent import build_agent
+
+app = FastAPI(title="AEC Agent")
+agent = None
+
+class ChatRequest(BaseModel):
+    message: str
+
+@app.on_event("startup")
+def _startup():
+    global agent
+    try:
+        agent = build_agent()
+    except Exception as e:
+        # if no key, agent remains None; expose health but return 503 on chat
+        agent = None
+
+@app.get("/health")
+def health():
+    return {"status":"ok","agent_ready": bool(agent)}
+
+@app.post("/chat")
+def chat(req: ChatRequest):
+    if not agent:
+        return {"error":"Agent is not ready. Set OPENAI_API_KEY or configure local provider."}
+    reply = agent.run(req.message)
+    return {"reply": reply}

--- a/services/orchestrator/app/client.py
+++ b/services/orchestrator/app/client.py
@@ -5,8 +5,6 @@ def mcp_client() -> httpx.Client:
     headers = {}
     if settings.MCP_API_KEY:
         headers["x-api-key"] = settings.MCP_API_KEY
-    return httpx.Client(
-        base_url=str(settings.MCP_BASE_URL),
-        headers=headers,
-        timeout=settings.REQUEST_TIMEOUT,
-    )
+    return httpx.Client(base_url=str(settings.MCP_BASE_URL),
+                        headers=headers,
+                        timeout=settings.REQUEST_TIMEOUT)

--- a/services/orchestrator/app/config.py
+++ b/services/orchestrator/app/config.py
@@ -1,5 +1,5 @@
 from pydantic_settings import BaseSettings
-from pydantic import Field, AnyUrl
+from pydantic import AnyUrl
 
 class Settings(BaseSettings):
     MCP_BASE_URL: AnyUrl = "http://localhost:8080"
@@ -7,6 +7,11 @@ class Settings(BaseSettings):
     MCP_REGION: str = "EU-Central"
     REQUEST_TIMEOUT: float = 30.0
     RETRIES: int = 3
+
+    LLM_PROVIDER: str = "openai"     # openai | local
+    LLM_MODEL: str = "gpt-4o-mini"
+    OPENAI_API_KEY: str | None = None
+    LOCAL_LLM_BASE_URL: str | None = None  # OpenAI-compatible endpoint
 
     class Config:
         env_file = ".env"

--- a/services/orchestrator/app/llm.py
+++ b/services/orchestrator/app/llm.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from langchain.chat_models.base import BaseChatModel
+from langchain_openai import ChatOpenAI
+from .config import settings
+import os
+
+def build_llm() -> BaseChatModel:
+    prov = (settings.LLM_PROVIDER or "openai").lower()
+    if prov == "openai":
+        key = settings.OPENAI_API_KEY or os.getenv("OPENAI_API_KEY")
+        if not key:
+            raise RuntimeError("OPENAI_API_KEY is not set. Export it or set in .env")
+        return ChatOpenAI(model=settings.LLM_MODEL, temperature=0, api_key=key)
+    elif prov == "local":
+        base = settings.LOCAL_LLM_BASE_URL or "http://localhost:8000/v1"
+        return ChatOpenAI(model=settings.LLM_MODEL, temperature=0, api_key="dummy", base_url=base)
+    else:
+        raise ValueError(f"Unknown LLM_PROVIDER={settings.LLM_PROVIDER}")

--- a/services/orchestrator/app/tools.py
+++ b/services/orchestrator/app/tools.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from typing import Optional, Dict, Any
+from langchain.tools import StructuredTool
+from pydantic import BaseModel, Field
+from .client import mcp_client
+from .config import settings
+
+class ParseInput(BaseModel):
+    file_uri: str = Field(..., description="resource://project/<id>/files/<file.pdf|.ifc>")
+
+class ExtractInput(BaseModel):
+    scope: Optional[Dict[str, Any]] = None
+
+class PriceInput(BaseModel):
+    bom: Dict[str, Any]
+    region: str = settings.MCP_REGION
+
+class SubsInput(BaseModel):
+    priced_bom: Dict[str, Any]
+    budget: Optional[str] = "low"
+
+class ExportInput(BaseModel):
+    project_id: str
+    priced_bom: Dict[str, Any]
+    filename_prefix: Optional[str] = None
+
+def _post(path: str, payload: dict) -> Dict[str, Any]:
+    with mcp_client() as c:
+        r = c.post(path, json=payload)
+        r.raise_for_status()
+        try:
+            return r.json()
+        except Exception:
+            return {"ok": True}
+
+def t_parse(file_uri: str) -> Dict[str, Any]:
+    return _post("/mcp/material/parse_drawing", {"file_uri": file_uri})
+
+def t_extract(scope: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return _post("/mcp/material/extract_bom", {"scope": scope or {}})
+
+def t_price(bom: Dict[str, Any], region: str = settings.MCP_REGION) -> Dict[str, Any]:
+    return _post("/mcp/material/price_bom", {"bom": bom, "region": region})
+
+def t_subs(priced_bom: Dict[str, Any], budget: Optional[str] = "low") -> Dict[str, Any]:
+    return _post("/mcp/material/suggest_substitutions", {"priced_bom": priced_bom, "constraints": {"budget": budget}})
+
+def t_export(project_id: str, priced_bom: Dict[str, Any], filename_prefix: Optional[str] = None) -> Dict[str, Any]:
+    out = {}
+    with mcp_client() as c:
+        for kind, path in [("json","/mcp/material/export/json"),
+                           ("excel","/mcp/material/export/excel"),
+                           ("pdf","/mcp/material/report/pdf")]:
+            payload = {"project_id": project_id, "priced_bom": priced_bom}
+            if filename_prefix:
+                payload["filename"] = f"{filename_prefix}.{ 'json' if kind=='json' else ('xlsx' if kind=='excel' else 'pdf') }"
+            r = c.post(path, json=payload); r.raise_for_status()
+            cd = r.headers.get("content-disposition","")
+            name = "output"
+            if "filename=" in cd:
+                name = cd.split("filename=",1)[1].strip('"')
+            out[kind] = f"data/projects/{project_id}/outputs/{name}"
+    return out
+
+parse_tool = StructuredTool.from_function(name="parse_drawing", description="Parse PDF/IFC into raw specs", func=t_parse, args_schema=ParseInput)
+extract_tool = StructuredTool.from_function(name="extract_bom", description="Normalize/build BOM from parsed scope", func=lambda scope=None: t_extract(scope), args_schema=ExtractInput)
+price_tool = StructuredTool.from_function(name="price_bom", description="Apply regional pricebook to BOM", func=lambda bom, region=settings.MCP_REGION: t_price(bom, region), args_schema=PriceInput)
+subs_tool = StructuredTool.from_function(name="suggest_substitutions", description="Suggest material alternatives for gaps", func=lambda priced_bom, budget="low": t_subs(priced_bom, budget), args_schema=SubsInput)
+export_tool = StructuredTool.from_function(name="export_results", description="Export PricedBOM to JSON/XLSX/PDF", func=lambda project_id, priced_bom, filename_prefix=None: t_export(project_id, priced_bom, filename_prefix), args_schema=ExportInput)

--- a/services/orchestrator/requirements.txt
+++ b/services/orchestrator/requirements.txt
@@ -6,3 +6,6 @@ pydantic-settings>=2.3
 tenacity>=8.2
 python-dotenv>=1.0
 orjson>=3.9
+openai>=1.35
+tiktoken>=0.7
+langchain-openai>=0.1

--- a/services/orchestrator/tests/test_agent_health.py
+++ b/services/orchestrator/tests/test_agent_health.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from app.chat_server import app
+
+def test_health():
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+    assert "agent_ready" in r.json()

--- a/services/orchestrator/tests/test_agent_import.py
+++ b/services/orchestrator/tests/test_agent_import.py
@@ -1,0 +1,3 @@
+def test_build_agent_imports():
+    from app.agent import build_agent
+    assert callable(build_agent)


### PR DESCRIPTION
## Summary
- integrate MCP and LLM settings
- add agent tools, HTTP chat server, CLI, and Makefile
- extend tests for agent import and health

## Testing
- `pip install -r services/orchestrator/requirements.txt`
- `pip install fastapi`
- `pip install python-multipart`
- `pytest services/orchestrator/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a89728de2c83229da4a683e2740f9e