### PR TITLE
Add evaluation pipeline for mcp-material

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -158,6 +158,18 @@ curl -X POST "http://localhost:8082/mcp/lca/estimate" \
 
 **Status**: Uses mock emission factors; integration with real EPD data is on the roadmap.
 
+## 4. Evaluation Pipeline (Step 12)
+
+The `mcp-material` service now includes a small evaluation pipeline with a
+curated dataset. Run inside `services/mcp-material`:
+
+```bash
+make eval
+```
+
+This generates JSON and Markdown reports under `eval/out/`. Evaluation for
+other services will be added in future steps.
+
 ## 4. Observability & Monitoring
 
 All services expose a `/metrics` endpoint compatible with Prometheus and a `/quality` endpoint with a JSON snapshot of the same metrics. Deployments typically include a Prometheus instance scraping each service and Grafana dashboards for latency, error rates and coverage ratios. The metric `pricing_coverage_ratio` tracks priced items vs total items and feeds quality dashboards.

--- a/services/mcp-material/Makefile
+++ b/services/mcp-material/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run dev test lint format docker-up docker-build
+.PHONY: run dev test lint format docker-up docker-build eval
 
 run:
 	PYTHONPATH=. uvicorn app.main:app --host 0.0.0.0 --port 8080
@@ -14,3 +14,6 @@ docker-build:
 
 docker-up:
 	docker compose up --build
+
+eval:
+	PYTHONPATH=. python -m eval.run_eval --output eval/out

--- a/services/mcp-material/README.md
+++ b/services/mcp-material/README.md
@@ -53,6 +53,16 @@ docker compose up --build
 pytest -q
 ```
 
+## Evaluation
+
+Запустить базовую проверку качества на подготовленном наборе кейсов:
+
+```bash
+make eval
+```
+
+Отчёты сохраняются в `eval/out/results.json` и `eval/out/report.md`.
+
 ## Переменные окружения
 
 | Name | Description | Default |

--- a/services/mcp-material/eval/data/cases.json
+++ b/services/mcp-material/eval/data/cases.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "case1",
+    "file": "spec.pdf",
+    "expected_items": [
+      {"name": "Бетон C25/30", "unit": "m3", "qty": 12.5},
+      {"name": "Арматура A500", "unit": "kg", "qty": 1500}
+    ]
+  },
+  {
+    "id": "case2",
+    "file": "spec.pdf",
+    "expected_items": [
+      {"name": "Бетон C25/30", "unit": "m3", "qty": 12.5},
+      {"name": "Арматура A500", "unit": "kg", "qty": 1500}
+    ]
+  },
+  {
+    "id": "case3",
+    "file": "spec.pdf",
+    "expected_items": [
+      {"name": "Бетон C25/30", "unit": "m3", "qty": 12.5},
+      {"name": "Арматура A500", "unit": "kg", "qty": 1500}
+    ]
+  }
+]

--- a/services/mcp-material/eval/data/files/spec.pdf
+++ b/services/mcp-material/eval/data/files/spec.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250822224309+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250822224309+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 222
+>>
+stream
+Gat=fbmM<A&;9M#ME+/BF>rH!Y:=kh\8NL7&F0-7%4)Q7q.WPGLY^pY*O6(\Qfn*'!>e1SB<[$&^k3Z#&)=N"FcK?CN'u#A.,@4(5!NZbI:m6)?N;+sM$8pELn3<8CX%8X:<EH22IGc%NSkabKG:?S+-OIj8agA2B>:=\/MV[Fk0oQLSX$i[P%QuAZ*etuW9:t!"Kd3`XAe0s0"OVpMbS;#T!cIo~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000304 00000 n 
+0000000507 00000 n 
+0000000575 00000 n 
+0000000871 00000 n 
+0000000930 00000 n 
+trailer
+<<
+/ID 
+[<fb060d0cc5e5bf051398863ded6bea85><fb060d0cc5e5bf051398863ded6bea85>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1242
+%%EOF

--- a/services/mcp-material/eval/dataset.py
+++ b/services/mcp-material/eval/dataset.py
@@ -1,0 +1,53 @@
+"""Evaluation dataset loader for mcp-material service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+import json
+
+from app.core.config import settings
+
+
+@dataclass
+class EvalCase:
+    """Single evaluation case.
+
+    Attributes:
+        id: Case identifier used as project id.
+        file_uri: resource:// URI to the input document.
+        expected_items: List of expected BOM items with name/unit/qty.
+    """
+
+    id: str
+    file_uri: str
+    expected_items: List[Dict[str, Any]]
+
+
+_DEF_DATA_PATH = Path(__file__).parent / "data"
+
+
+def load_dataset(path: Path | None = None) -> List[EvalCase]:
+    """Load evaluation cases from JSON file.
+
+    The JSON is expected to have entries with ``id``, ``file`` (relative
+    to ``data/files``) and ``expected_items``. Files are copied into the
+    service ``DATA_ROOT`` so that they can be accessed via ``resource://``
+    URIs when calling the API.
+    """
+
+    base = path or _DEF_DATA_PATH
+    data_file = base / "cases.json"
+    raw_cases = json.loads(data_file.read_text(encoding="utf-8"))
+    cases: List[EvalCase] = []
+    for c in raw_cases:
+        cid = c["id"]
+        fname = c["file"]
+        src = base / "files" / fname
+        # Place file under DATA_ROOT/projects/<id>/files
+        dst = settings.DATA_ROOT / "projects" / cid / "files" / fname
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(src.read_bytes())
+        file_uri = f"resource://project/{cid}/files/{fname}"
+        cases.append(EvalCase(id=cid, file_uri=file_uri, expected_items=c["expected_items"]))
+    return cases

--- a/services/mcp-material/eval/metrics.py
+++ b/services/mcp-material/eval/metrics.py
@@ -1,0 +1,51 @@
+"""Computation of quality metrics for evaluation cases."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .dataset import EvalCase
+
+
+def compute_case_metrics(case: EvalCase, priced_bom: Dict) -> Dict:
+    """Compute metrics for a single evaluation case."""
+    expected = case.expected_items
+    total = len(expected)
+    priced_items = priced_bom.get("items") or []
+    gaps = priced_bom.get("gaps") or []
+
+    coverage = len(priced_items) / total if total else 0.0
+
+    # Mock precision@1: compare first N priced items to expected items in order
+    correct = 0
+    for i, exp in enumerate(expected):
+        if i < len(priced_items) and priced_items[i].get("name") == exp.get("name"):
+            correct += 1
+    precision_at_1 = correct / total if total else 0.0
+
+    gap_stats: Dict[str, int] = {}
+    for g in gaps:
+        reason = g.get("reason", "unknown")
+        gap_stats[reason] = gap_stats.get(reason, 0) + 1
+
+    return {
+        "case_id": case.id,
+        "coverage": coverage,
+        "precision_at_1": precision_at_1,
+        "gap_stats": gap_stats,
+    }
+
+
+def aggregate_metrics(case_metrics: List[Dict]) -> Dict:
+    """Aggregate metrics across cases."""
+    if not case_metrics:
+        return {"coverage": 0.0, "precision_at_1": 0.0, "gap_stats": {}}
+    agg = {"coverage": 0.0, "precision_at_1": 0.0, "gap_stats": {}}
+    for m in case_metrics:
+        agg["coverage"] += m.get("coverage", 0.0)
+        agg["precision_at_1"] += m.get("precision_at_1", 0.0)
+        for k, v in m.get("gap_stats", {}).items():
+            agg["gap_stats"][k] = agg["gap_stats"].get(k, 0) + v
+    n = len(case_metrics)
+    agg["coverage"] /= n
+    agg["precision_at_1"] /= n
+    return agg

--- a/services/mcp-material/eval/report.py
+++ b/services/mcp-material/eval/report.py
@@ -1,0 +1,46 @@
+"""Reporting utilities for evaluation results."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+import json
+
+
+def write_reports(results: List[Dict], aggregate: Dict, out_dir: Path) -> None:
+    """Write JSON and Markdown reports.
+
+    Parameters
+    ----------
+    results:
+        List of per-case dictionaries containing at least ``case_id`` and
+        ``metrics``.
+    aggregate:
+        Dictionary with aggregate metrics.
+    out_dir:
+        Output directory where ``results.json`` and ``report.md`` will be
+        created.
+    """
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    data = {"cases": results, "aggregate": aggregate}
+    (out_dir / "results.json").write_text(
+        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    lines = ["| Case | Coverage | Precision@1 | Gaps |", "|------|----------|-------------|------|"]
+    for r in results:
+        m = r.get("metrics", {})
+        gaps = sum(m.get("gap_stats", {}).values())
+        lines.append(
+            f"| {r.get('case_id')} | {m.get('coverage', 0):.2f} | {m.get('precision_at_1', 0):.2f} | {gaps} |"
+        )
+    lines.append("")
+    agg_line = (
+        f"**Aggregate**: coverage={aggregate.get('coverage',0):.2f}, "
+        f"precision@1={aggregate.get('precision_at_1',0):.2f}, "
+        f"gaps={sum(aggregate.get('gap_stats',{}).values())}"
+    )
+    lines.append(agg_line)
+    (out_dir / "report.md").write_text("\n".join(lines), encoding="utf-8")

--- a/services/mcp-material/eval/run_eval.py
+++ b/services/mcp-material/eval/run_eval.py
@@ -1,0 +1,37 @@
+"""CLI entrypoint for evaluation pipeline."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List, Dict
+
+from fastapi.testclient import TestClient
+
+from .dataset import load_dataset, EvalCase
+from .runner import run_cases
+from .metrics import compute_case_metrics, aggregate_metrics
+from .report import write_reports
+from app.main import app
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run evaluation for mcp-material")
+    parser.add_argument("--output", default="eval/out", help="Output directory for reports")
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.output)
+    cases = load_dataset()
+    client = TestClient(app)
+    raw_results = run_cases(cases, client)
+
+    case_results: List[Dict] = []
+    for case, res in zip(cases, raw_results):
+        metrics = compute_case_metrics(case, res["priced_bom"])
+        case_results.append({"case_id": case.id, "metrics": metrics, "priced_bom": res["priced_bom"]})
+
+    aggregate = aggregate_metrics([r["metrics"] for r in case_results])
+    write_reports(case_results, aggregate, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mcp-material/eval/runner.py
+++ b/services/mcp-material/eval/runner.py
@@ -1,0 +1,45 @@
+"""Run evaluation cases through the service endpoints."""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+from fastapi.testclient import TestClient
+
+from .dataset import EvalCase
+from app.main import app
+
+
+def run_case(client: TestClient, case: EvalCase) -> Dict[str, Any]:
+    """Execute service pipeline for a single case.
+
+    Returns a dictionary with ``case_id`` and ``priced_bom`` obtained from
+    the API calls.
+    """
+
+    r = client.post("/mcp/material/parse_drawing", json={"file_uri": case.file_uri})
+    r.raise_for_status()
+    specs = r.json().get("specs", [])
+
+    bom_items = []
+    for s in specs:
+        name = s.get("name")
+        unit = s.get("unit")
+        qty = s.get("qty")
+        if not name or unit is None or qty is None:
+            continue
+        bom_items.append({"name": name, "unit": unit, "qty": qty})
+
+    r2 = client.post(
+        "/mcp/material/price_bom",
+        json={"bom": {"items": bom_items}, "region": "EU-Central"},
+    )
+    r2.raise_for_status()
+    priced_bom = r2.json()
+    return {"case_id": case.id, "priced_bom": priced_bom}
+
+
+def run_cases(cases: List[EvalCase], client: TestClient | None = None) -> List[Dict[str, Any]]:
+    client = client or TestClient(app)
+    results = []
+    for case in cases:
+        results.append(run_case(client, case))
+    return results

--- a/services/mcp-material/tests/test_eval_pipeline.py
+++ b/services/mcp-material/tests/test_eval_pipeline.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from app.main import app
+from eval.dataset import load_dataset
+from eval import runner, metrics, report
+
+
+def test_eval_pipeline(tmp_path, monkeypatch):
+    cases = load_dataset()
+    case = cases[0]
+
+    def fake_run_case(client, case):
+        return {
+            "case_id": case.id,
+            "priced_bom": {
+                "items": [
+                    {
+                        "name": "Бетон C25/30",
+                        "unit": "m3",
+                        "qty": 12.5,
+                        "unit_price": 95.4,
+                        "currency": "EUR",
+                    }
+                ],
+                "subtotal": 100.0,
+                "currency": "EUR",
+                "gaps": [],
+            },
+        }
+
+    monkeypatch.setattr(runner, "run_case", fake_run_case)
+
+    client = TestClient(app)
+    results = runner.run_cases([case], client)
+    case_metrics = [metrics.compute_case_metrics(case, r["priced_bom"]) for r in results]
+    agg = metrics.aggregate_metrics(case_metrics)
+
+    out_dir = tmp_path / "out"
+    report.write_reports(
+        [{"case_id": case.id, "metrics": case_metrics[0]}], agg, out_dir
+    )
+
+    assert "coverage" in case_metrics[0]
+    assert "precision_at_1" in case_metrics[0]
+    assert (out_dir / "results.json").exists()
+    assert (out_dir / "report.md").exists()


### PR DESCRIPTION
## Summary
- add evaluation dataset loader, runner, metrics, and report utilities
- provide CLI and Makefile target to generate JSON and Markdown evaluation reports
- document how to run the new evaluation workflow and add test coverage

## Testing
- `make eval`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f23985f48322a643d2218b1cfab5