### PR TITLE
Add strict JSON validation and repair utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: lint test
+
+lint:
+	ruff check src tests
+	black --check src tests
+
+test:
+	pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "--cov=core --cov-report=term-missing"
+testpaths = ["tests"]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for JSON validation used in tests."""
+
+from .validator import validate, try_repair_strict_json
+
+__all__ = ["validate", "try_repair_strict_json"]

--- a/src/core/schemas/__init__.py
+++ b/src/core/schemas/__init__.py
@@ -1,0 +1,21 @@
+"""Utilities for loading JSON schemas used in tests."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any, Dict
+
+
+def load_schema(name: str) -> Dict[str, Any]:
+    """Load a JSON schema by ``name``.
+
+    The function looks for ``"{name}.schema.json"`` inside this package and
+    returns the parsed dictionary.
+    """
+    with (
+        resources.files(__package__)
+        .joinpath(f"{name}.schema.json")
+        .open("r", encoding="utf-8") as f
+    ):
+        return json.load(f)

--- a/src/core/schemas/company.schema.json
+++ b/src/core/schemas/company.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "site": {"type": "string", "format": "uri"},
+        "registered_at": {"type": "string", "format": "date"},
+        "inn": {"type": "string", "pattern": "^[0-9]{10}$"},
+        "ogrn": {"type": "string", "pattern": "^[0-9]{13}$"},
+        "capital": {"type": ["number", "null"]},
+        "debt": {"type": ["number", "null"]},
+        "loss": {"type": ["number", "null"]},
+        "currency": {"type": "string", "enum": ["RUB", "USD"]},
+        "tags": {"type": "array", "items": {"type": "string"}}
+    },
+    "required": ["name", "site", "registered_at", "inn", "ogrn", "currency"],
+    "additionalProperties": false
+}

--- a/src/core/validator.py
+++ b/src/core/validator.py
@@ -1,0 +1,225 @@
+"""Validation helpers for project schemas.
+
+This module provides two public functions:
+
+``validate(obj, schema_name)``
+    Validate a Python ``dict`` against the named JSON schema.  Raises
+    :class:`jsonschema.exceptions.ValidationError` with a message containing
+    the failing JSON path when validation does not succeed.
+
+``try_repair_strict_json(s, schema_name)``
+    Attempt to repair a slightly malformed JSON string, parse it and then
+    validate it against the schema.  Only the following defects are corrected:
+
+    * UTF-8 BOM at the beginning of the string.
+    * Surrounding whitespace.
+    * Single quotes used for keys or string values.
+    * JavaScript style comments (``//`` and ``/* ... */``).
+    * Trailing commas in objects and arrays.
+    * ``NaN``, ``Infinity`` and ``-Infinity`` literals (replaced with ``null``).
+
+Any other structural issues result in an immediate parsing error.  After repair
+and parsing the resulting object is validated using :func:`validate`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import copy
+import json
+import re
+from typing import Any, Dict
+
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError
+
+from .schemas import load_schema
+
+try:  # optional, for faster parsing if available
+    import orjson  # type: ignore
+except Exception:  # pragma: no cover - fallback branch
+    orjson = None  # type: ignore
+
+
+@dataclass
+class _ParserState:
+    """Simple state machine for stripping comments and literals."""
+
+    in_string: bool = False
+    escape: bool = False
+    string_char: str = ""
+    in_line_comment: bool = False
+    in_block_comment: bool = False
+
+
+def validate(obj: Dict[str, Any], schema_name: str) -> None:
+    """Validate ``obj`` against schema ``schema_name``.
+
+    Parameters
+    ----------
+    obj:
+        Python dictionary representing JSON data.  The object is not modified.
+    schema_name:
+        Name of the schema file without ``.schema.json`` extension.
+
+    Raises
+    ------
+    jsonschema.exceptions.ValidationError
+        If the object does not conform to the schema.  The error message
+        contains the failing JSON path and a readable description.
+    """
+
+    schema = load_schema(schema_name)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    try:
+        validator.validate(copy.deepcopy(obj))
+    except ValidationError as exc:  # pragma: no cover - exercised in tests
+        path = exc.json_path
+        if exc.validator == "required" and "required property" in exc.message:
+            missing = exc.message.split("'", 2)[1]
+            path = f"{path}.{missing}" if path != "$" else f"$.{missing}"
+        exc.message = f"{path}: {exc.message}"
+        raise
+
+
+def _replace_single_quotes(text: str) -> str:
+    """Replace single-quoted strings with double quotes."""
+
+    def repl(match: re.Match[str]) -> str:
+        inner = match.group(1).replace("\\'", "'")
+        return f'"{inner}"'
+
+    return re.sub(r"(?<!\\)'([^'\\]*(?:\\.[^'\\]*)*)'", repl, text)
+
+
+def _strip_comments_and_commas(text: str) -> str:
+    state = _ParserState()
+    result: list[str] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < length else ""
+        if state.in_string:
+            result.append(ch)
+            if state.escape:
+                state.escape = False
+            elif ch == "\\":
+                state.escape = True
+            elif ch == state.string_char:
+                state.in_string = False
+            i += 1
+            continue
+        if state.in_line_comment:
+            if ch in "\n\r":
+                state.in_line_comment = False
+            i += 1
+            continue
+        if state.in_block_comment:
+            if ch == "*" and nxt == "/":
+                state.in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            state.in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            state.in_block_comment = True
+            i += 2
+            continue
+        if ch in {'"', "'"}:
+            state.in_string = True
+            state.string_char = ch
+            result.append(ch)
+            i += 1
+            continue
+        result.append(ch)
+        i += 1
+    cleaned = "".join(result)
+    # Remove trailing commas in objects and arrays
+    cleaned = re.sub(r",(\s*[}\]])", r"\1", cleaned)
+    return cleaned
+
+
+def _replace_invalid_literals(text: str) -> str:
+    state = _ParserState()
+    result: list[str] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        ch = text[i]
+        if state.in_string:
+            result.append(ch)
+            if state.escape:
+                state.escape = False
+            elif ch == "\\":
+                state.escape = True
+            elif ch == state.string_char:
+                state.in_string = False
+            i += 1
+            continue
+        if ch in {'"', "'"}:
+            state.in_string = True
+            state.string_char = ch
+            result.append(ch)
+            i += 1
+            continue
+        if text.startswith("-Infinity", i):
+            result.append("null")
+            i += 9
+            continue
+        if text.startswith("Infinity", i):
+            result.append("null")
+            i += 8
+            continue
+        if text.startswith("NaN", i):
+            result.append("null")
+            i += 3
+            continue
+        result.append(ch)
+        i += 1
+    return "".join(result)
+
+
+def try_repair_strict_json(s: str, schema_name: str) -> Dict[str, Any]:
+    """Repair a slightly malformed JSON string and validate it.
+
+    Parameters
+    ----------
+    s:
+        String containing JSON data with possible minor defects listed in the
+        module documentation.
+    schema_name:
+        Name of the JSON schema used for validation.
+
+    Returns
+    -------
+    dict
+        Parsed JSON object.
+
+    Raises
+    ------
+    json.decoder.JSONDecodeError
+        If the string cannot be parsed into JSON after repair.
+    jsonschema.exceptions.ValidationError
+        If the parsed object does not conform to the schema.
+    """
+
+    s = s.lstrip("\ufeff").strip()
+    s = _replace_single_quotes(s)
+    s = _strip_comments_and_commas(s)
+    s = _replace_invalid_literals(s)
+
+    try:
+        if orjson is not None:  # pragma: no cover - optional branch
+            obj = orjson.loads(s)
+        else:  # pragma: no cover - optional branch
+            obj = json.loads(s)
+    except json.JSONDecodeError as exc:  # pragma: no cover - tested via raise
+        raise exc
+
+    validate(obj, schema_name)
+    return obj

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,160 @@
+from json.decoder import JSONDecodeError
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from core import validate, try_repair_strict_json
+
+
+VALID_COMPANY = {
+    "name": "ACME",
+    "site": "https://example.com",
+    "registered_at": "2023-01-01",
+    "inn": "1234567890",
+    "ogrn": "1234567890123",
+    "capital": 1000,
+    "debt": 0,
+    "loss": 0,
+    "currency": "RUB",
+    "tags": ["a", "b"],
+}
+
+
+# --- tests for validate -----------------------------------------------------
+
+
+def test_validate_success():
+    validate(VALID_COMPANY, "company")
+
+
+def test_validate_type_error():
+    bad = dict(VALID_COMPANY, capital="oops")
+    with pytest.raises(ValidationError) as exc:
+        validate(bad, "company")
+    assert "$.capital" in str(exc.value)
+
+
+def test_validate_enum_error():
+    bad = dict(VALID_COMPANY, currency="EUR")
+    with pytest.raises(ValidationError) as exc:
+        validate(bad, "company")
+    assert "$.currency" in str(exc.value)
+
+
+def test_validate_required_field():
+    bad = dict(VALID_COMPANY)
+    del bad["inn"]
+    with pytest.raises(ValidationError) as exc:
+        validate(bad, "company")
+    assert "$.inn" in str(exc.value)
+
+
+def test_validate_format_errors():
+    bad = dict(VALID_COMPANY, registered_at="2023-13-01", site="not-a-uri")
+    with pytest.raises(ValidationError) as exc:
+        validate(bad, "company")
+    # path to the first failing field can be either registered_at or site
+    assert any(p in str(exc.value) for p in ("$.registered_at", "$.site"))
+
+
+def test_validate_pattern_error():
+    bad = dict(VALID_COMPANY, inn="123", ogrn="123")
+    with pytest.raises(ValidationError) as exc:
+        validate(bad, "company")
+    assert "$.inn" in str(exc.value)
+
+
+# --- tests for try_repair_strict_json ---------------------------------------
+
+
+def base_json_string(extra: str = ""):
+    return (
+        "{'name': 'ACME', 'site': 'https://example.com',"
+        " 'registered_at': '2023-01-01', 'inn': '1234567890',"
+        " 'ogrn': '1234567890123', 'currency': 'RUB'" + extra + "}"
+    )
+
+
+def test_repair_handles_bom():
+    s = "\ufeff" + base_json_string()
+    obj = try_repair_strict_json(s, "company")
+    assert obj["name"] == "ACME"
+
+
+def test_repair_single_quotes():
+    s = base_json_string()
+    obj = try_repair_strict_json(s, "company")
+    assert obj["currency"] == "RUB"
+
+
+def test_repair_removes_comments():
+    s = """
+    {
+      // comment
+      'name': 'ACME', /* block */
+      'site': 'https://example.com',
+      'registered_at': '2023-01-01', // tail
+      'inn': '1234567890',
+      'ogrn': '1234567890123',
+      'currency': 'RUB'
+    }
+    """
+    obj = try_repair_strict_json(s, "company")
+    assert obj["inn"] == "1234567890"
+
+
+def test_repair_trailing_comma_object():
+    s = base_json_string(",")
+    obj = try_repair_strict_json(s, "company")
+    assert obj["ogrn"] == "1234567890123"
+
+
+def test_repair_trailing_comma_array():
+    s = (
+        "{'name': 'ACME', 'site': 'https://example.com',"
+        " 'registered_at': '2023-01-01', 'inn': '1234567890',"
+        " 'ogrn': '1234567890123', 'currency': 'RUB', 'tags': ['a', 'b',],}"
+    )
+    obj = try_repair_strict_json(s, "company")
+    assert obj["tags"] == ["a", "b"]
+
+
+def test_repair_nan_and_infinity():
+    s = (
+        "{'name': 'ACME', 'site': 'https://example.com',"
+        " 'registered_at': '2023-01-01', 'inn': '1234567890',"
+        " 'ogrn': '1234567890123', 'currency': 'RUB',"
+        " 'capital': NaN, 'debt': Infinity, 'loss': -Infinity}"
+    )
+    obj = try_repair_strict_json(s, "company")
+    assert obj["capital"] is None
+    assert obj["debt"] is None and obj["loss"] is None
+
+
+def test_repair_invalid_date():
+    s = base_json_string().replace("2023-01-01", "2023-13-01")
+    with pytest.raises(ValidationError):
+        try_repair_strict_json(s, "company")
+
+
+def test_repair_invalid_inn():
+    s = base_json_string().replace("1234567890", "12")
+    with pytest.raises(ValidationError):
+        try_repair_strict_json(s, "company")
+
+
+def test_repair_parse_error():
+    s = "{'name': 'ACME'"  # missing closing brace
+    with pytest.raises(JSONDecodeError):
+        try_repair_strict_json(s, "company")
+
+
+def test_repair_handles_escape_sequences():
+    s = (
+        "{'name': 'ACME', 'site': 'https://example.com',"
+        " 'registered_at': '2023-01-01', 'inn': '1234567890',"
+        " 'ogrn': '1234567890123', 'currency': 'RUB',"
+        " 'tags': ['a\\\\b']}"
+    )
+    obj = try_repair_strict_json(s, "company")
+    assert obj["tags"][0] == "a\\b"


### PR DESCRIPTION
## Summary
- implement `validate` using Draft202012Validator and detailed path-aware errors
- add `try_repair_strict_json` to normalize slightly malformed JSON and validate
- provide extensive tests for validation and JSON repairs

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c57112d78c83228a4f660c048cf94e